### PR TITLE
fix(macros): place _start_rust in .init.rust section

### DIFF
--- a/crates/airbender-macros/src/lib.rs
+++ b/crates/airbender-macros/src/lib.rs
@@ -101,6 +101,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         #input
 
         #[no_mangle]
+        #[link_section = ".init.rust"]
         #[export_name = "_start_rust"]
         pub extern "C" fn #wrapper_name() -> ! {
             #start_call


### PR DESCRIPTION
## Problem

The `#[airbender::main]` macro generates `_start_rust` without a `#[link_section]` attribute, so it lands in the default `.text` section. The linker script (`link.x`) places `.init.rust` right after `.init` (boot assembly), but all other `.text.*` sections come later.

The boot assembly in `.init` uses `jal zero, _start_rust`, which has a ±1 MB range (RISC-V JAL 20-bit signed immediate). For guest binaries with `.text` sections exceeding 1 MB, `_start_rust` ends up out of range:

```
rust-lld: error: relocation R_RISCV_JAL out of range: 1058512 is not in [-1048576, 1048575]; references '_start_rust'
```

This was hit in [zksync-os](https://github.com/matter-labs/zksync-os) which produces ~2 MB guest binaries.

## Fix

Add `#[link_section = ".init.rust"]` to the generated `_start_rust` wrapper. This places it adjacent to `.init` in the linker script layout, guaranteeing it's within JAL range regardless of binary size.

Verified: `_start_rust` moves from `0x000fd1f8` to `0x00000024` (right after boot assembly).