### PR TITLE
fix(build): canonicalize mount_root in reproducible builds

### DIFF
--- a/crates/airbender-build/src/build/docker.rs
+++ b/crates/airbender-build/src/build/docker.rs
@@ -275,8 +275,13 @@ impl<'a> ReproducibleBuild<'a> {
             .project_dir
             .canonicalize()
             .unwrap_or_else(|_| self.params.project_dir.to_path_buf());
+        let mount_root_abs = self
+            .params
+            .mount_root
+            .canonicalize()
+            .unwrap_or_else(|_| self.params.mount_root.to_path_buf());
         let project_rel = project_abs
-            .strip_prefix(&self.params.mount_root)
+            .strip_prefix(&mount_root_abs)
             .unwrap_or(Path::new(""));
         let workdir = format!("/src/{}", project_rel.display());
         let build_cmd = build_container_cmd(


### PR DESCRIPTION
## Summary

`--workspace-root` with a relative path (e.g. `..`) caused `--reproducible` builds to fail for crates excluded from the workspace.

The issue: `mount_root` was stored as an un-canonicalized path (e.g. `/foo/bar/..`), while `project_dir` was canonicalized (e.g. `/foo`). `strip_prefix` failed to compute the relative path, defaulting the Docker workdir to `/src` (the mount root). Cargo then resolved from the workspace root, couldn't find the excluded package, and errored with "no bin target named X".

Fix: canonicalize `mount_root` before `strip_prefix`.

## Reproduction

```bash
# In a monorepo where zksync_os is excluded from the workspace
cd zksync_os
cargo airbender build --reproducible --workspace-root .. --app-name foo --release
# Before fix: "error: no bin target named `foo` in default-run packages"
# After fix: builds correctly from /src/zksync_os inside the container
```

## Test plan

- [x] Verified locally with zksync-os (excluded workspace member with path deps to parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)