### PR TITLE
chore: update zksync-airbender dep to latest dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -565,7 +565,7 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "unroll",
@@ -852,7 +852,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "console"
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -1250,13 +1250,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.2",
  "seq-macro",
@@ -1378,7 +1378,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1707,7 +1707,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1796,7 +1796,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -1950,7 +1950,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -2467,7 +2467,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -2586,7 +2586,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2795,7 +2795,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2947,7 +2947,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3089,7 +3089,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -3268,7 +3268,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -3318,7 +3318,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -3396,7 +3396,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3564,7 +3564,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#9650fd4241f133d5d76c13d290713716e69f5d91"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/cycle-markers/guest/Cargo.lock
+++ b/examples/cycle-markers/guest/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "unroll",
@@ -307,7 +307,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const-oid"
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/cycle-markers/host/Cargo.lock
+++ b/examples/cycle-markers/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -94,7 +94,7 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.8",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +588,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const_format"
@@ -639,15 +630,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -712,18 +694,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -782,18 +755,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -909,7 +872,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -922,7 +885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -958,7 +921,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -971,7 +934,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1015,7 +978,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1085,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1139,15 +1102,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1204,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1216,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1265,7 +1219,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1277,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1290,23 +1244,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1318,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1346,7 +1290,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1358,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1368,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1380,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1430,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1442,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1454,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1464,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1474,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -1707,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1732,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1903,7 +1847,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1912,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1922,7 +1866,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2127,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2147,7 +2091,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2160,7 +2104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2171,23 +2115,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2199,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2392,7 +2326,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2406,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -2446,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2529,7 +2463,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2541,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2579,7 +2513,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2594,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2806,7 +2740,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/fibonacci/guest/Cargo.lock
+++ b/examples/fibonacci/guest/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "getrandom"
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/fibonacci/host/Cargo.lock
+++ b/examples/fibonacci/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -94,7 +94,7 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.8",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +588,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const_format"
@@ -639,15 +630,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -712,18 +694,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -782,18 +755,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -909,7 +872,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -922,7 +885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -958,7 +921,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -971,7 +934,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1015,7 +978,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1085,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1139,15 +1102,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1204,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1216,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1265,7 +1219,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1277,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1290,23 +1244,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1318,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1346,7 +1290,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1358,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1368,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1380,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1430,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1442,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1454,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1464,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1474,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -1707,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1732,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1903,7 +1847,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1912,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1922,7 +1866,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2127,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2147,7 +2091,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2160,7 +2104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2171,23 +2115,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2199,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2392,7 +2326,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2406,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -2446,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2529,7 +2463,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2541,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2579,7 +2513,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2594,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2806,7 +2740,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/revm-basic/guest/Cargo.lock
+++ b/examples/revm-basic/guest/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#d5c2058acb68209ba84ab1bdcd207df3881b00f9"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const-hex"
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#d5c2058acb68209ba84ab1bdcd207df3881b00f9"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/revm-basic/host/Cargo.lock
+++ b/examples/revm-basic/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -86,7 +86,7 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.8",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
@@ -204,7 +204,7 @@ dependencies = [
  "ruint",
  "rustc-hash",
  "serde",
- "sha3 0.10.8",
+ "sha3",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "unroll",
 ]
@@ -779,15 +779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -986,7 +977,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const-hex"
@@ -995,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "proptest",
  "serde_core",
 ]
@@ -1055,15 +1046,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1155,18 +1137,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -1313,20 +1286,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1491,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -1503,7 +1466,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -1555,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -1568,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1624,7 +1587,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1714,7 +1677,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1826,15 +1789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1950,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2009,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2021,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2047,17 +2001,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2073,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2085,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2125,7 +2069,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2137,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2147,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2159,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2209,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2221,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2233,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2243,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2253,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -2653,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -2678,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -3098,7 +3042,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -3107,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -3117,7 +3061,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -3437,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -3457,7 +3401,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -3470,7 +3414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -3481,17 +3425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -3507,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -3519,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -3797,7 +3731,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -3811,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -3861,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -3950,7 +3884,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -3962,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -4000,7 +3934,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -4015,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -4459,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/std-btreemap/guest/Cargo.lock
+++ b/examples/std-btreemap/guest/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "getrandom"
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/std-btreemap/host/Cargo.lock
+++ b/examples/std-btreemap/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -87,7 +87,7 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.8",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
@@ -375,7 +375,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +588,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const_format"
@@ -639,15 +630,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -712,18 +694,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -782,18 +755,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -909,7 +872,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -922,7 +885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -958,7 +921,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -971,7 +934,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1015,7 +978,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1085,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1139,15 +1102,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1204,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1216,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1265,7 +1219,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1277,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1290,23 +1244,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1318,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1346,7 +1290,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1358,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1368,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1380,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1430,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1442,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1454,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1464,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1474,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -1707,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1732,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1903,7 +1847,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1912,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1922,7 +1866,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2127,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2147,7 +2091,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2160,7 +2104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2171,23 +2115,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2199,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2392,7 +2326,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2406,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -2446,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2529,7 +2463,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2541,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2579,7 +2513,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2594,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2806,7 +2740,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/u256-add/guest/Cargo.lock
+++ b/examples/u256-add/guest/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "getrandom"
@@ -228,7 +228,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#c16b75d2df36af2608fb971c3a75af83cd1c997d"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/u256-add/host/Cargo.lock
+++ b/examples/u256-add/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -87,7 +87,7 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.8",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
@@ -376,7 +376,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "unroll",
 ]
@@ -469,15 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -598,7 +589,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "const_format"
@@ -640,15 +631,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -713,18 +695,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -783,18 +756,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -910,7 +873,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -923,7 +886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -959,7 +922,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "seq-macro",
@@ -972,7 +935,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1016,7 +979,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1086,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1140,15 +1103,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1205,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1217,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1266,7 +1220,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1278,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1291,23 +1245,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1319,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1347,7 +1291,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1359,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1369,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1381,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1431,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1443,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -1455,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1465,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -1475,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 
 [[package]]
 name = "ntapi"
@@ -1708,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1733,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1904,7 +1848,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1913,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1923,7 +1867,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2128,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2148,7 +2092,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2161,7 +2105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2172,23 +2116,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2200,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2393,7 +2327,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2407,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "worker",
@@ -2447,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2530,7 +2464,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "common_constants",
  "prover",
@@ -2542,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "field",
  "unroll",
@@ -2580,7 +2514,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2595,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2807,7 +2741,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#4844b40a57e8b04189cf8587170469b9b7d61274"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#b4817570fc43da8d789846d48719478122701037"
 dependencies = [
  "num_cpus",
  "rayon",


### PR DESCRIPTION
## Summary

- Update all `Cargo.lock` files to use the latest commit on the `zksync-airbender` `dev` branch (`b4817570fc43da8d789846d48719478122701037`)
- The workspace `Cargo.toml` already references `branch = "dev"` — only lock files needed updating
- All 11 lock files updated: root workspace + all 5 example guest/host pairs

## Test plan

- [x] `cargo check --workspace` passes locally with `ZKSYNC_USE_CUDA_STUBS=true`
- [x] All example lock files updated to latest dev commit
- [x] Cargo deny, license check, secrets scan, and PR title checks pass on fork CI
- [ ] Full CI (requires self-hosted runners from the org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)