### PR TITLE
feat(rt): make QuasiUart::write_byte and flush public

### DIFF
--- a/crates/airbender-rt/src/uart.rs
+++ b/crates/airbender-rt/src/uart.rs
@@ -29,7 +29,7 @@ impl QuasiUart {
     }
 
     #[inline(never)]
-    fn write_byte(&mut self, byte: u8) {
+    pub fn write_byte(&mut self, byte: u8) {
         self.buffer[self.len] = byte;
         self.len += 1;
         if self.len == 4 {
@@ -39,7 +39,7 @@ impl QuasiUart {
         }
     }
 
-    fn flush(&mut self) {
+    pub fn flush(&mut self) {
         if self.len == 0 {
             self.buffer.fill(0);
             return;


### PR DESCRIPTION
## Summary

Expose `QuasiUart::write_byte` and `QuasiUart::flush` as `pub`.

## Why

The only public way to emit output through `QuasiUart` today is `core::fmt::Write::write_str`, which calls `write_entry_sequence` internally. Each `write_str` therefore emits a full HELLO_MARKER + length prefix.

That works for a single formatted message, but not for callers that need to emit one entry sequence followed by many small writes. A concrete example is a logger that hex-encodes a byte iterator: it wants to call `write_entry_sequence(2 * len)` once, then stream two hex characters per input byte. Doing this via `write_str` would produce a new entry sequence per byte pair, breaking the UART protocol.

Exposing `write_byte` and `flush` lets such callers follow the same pattern the `write_str` impl uses internally:

```rust
uart.write_entry_sequence(expected_len);
for byte in src {
    uart.write_byte(hi_hex(byte));
    uart.write_byte(lo_hex(byte));
}
uart.flush();
```

In zksync-os specifically, this would let us drop a byte-for-byte copy of `QuasiUart` that we maintain today only because the needed methods are private upstream.

## Test plan

- [x] `cargo check -p airbender-rt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)