### PR TITLE
feat!: (Breaking!) Implement support for 80/100 bit security

### DIFF
--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -43,10 +43,11 @@ jobs:
           wget -q -O - https://sh.rustup.rs | bash -s -- -y --default-toolchain "$RUST_TOOLCHAIN" --profile minimal
           echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
           echo "export PATH=\"$HOME/.cargo/bin:\$PATH\"" >> "${HOME}/.bash_profile"
-          rustup component add rust-src llvm-tools-preview
 
-      - name: Install cargo-binutils
-        run: cargo install cargo-binutils --locked
+      - name: Install Rust prerequisites
+        run: |
+          rustup component add rust-src llvm-tools-preview
+          cargo install cargo-binutils --locked
 
       # We need cmake 3.30 because older cmake versions do not properly pass cuda_standard_20.
       - name: Setup CMake

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -1,0 +1,189 @@
+name: Test on GPU
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+env:
+  # Keep this value in sync with rust-toolchain.toml.
+  RUST_TOOLCHAIN: nightly-2026-02-10
+
+jobs:
+  airbender-platform-gpu-build:
+    runs-on: [ matterlabs-ci-runner-highmem ]
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        # matterlabs-ci-gpu-runner currently has CUDA 12.2 driver support only, so
+        # CUDA 13-compiled binaries are not runnable there.
+        cuda: [ "12.9.1-devel-ubuntu22.04" ]
+    container:
+      image: nvidia/cuda:${{ matrix.cuda }}
+    steps:
+      - name: Prepare environment
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt update
+          apt install -y build-essential ca-certificates clang cmake curl git libssl-dev lld pkg-config wget
+          echo "/usr/local/nvidia/bin:/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@v4
+
+      - name: Setup rustup
+        run: |
+          wget -q -O - https://sh.rustup.rs | bash -s -- -y --default-toolchain "$RUST_TOOLCHAIN" --profile minimal
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          echo "export PATH=\"$HOME/.cargo/bin:\$PATH\"" >> "${HOME}/.bash_profile"
+          rustup component add rust-src llvm-tools-preview
+
+      - name: Install cargo-binutils
+        run: cargo install cargo-binutils --locked
+
+      # We need cmake 3.30 because older cmake versions do not properly pass cuda_standard_20.
+      - name: Setup CMake
+        run: |
+          curl -LO https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2-linux-x86_64.sh
+          chmod +x cmake-3.30.2-linux-x86_64.sh
+          ./cmake-3.30.2-linux-x86_64.sh --skip-license --prefix=/usr/local
+
+      - name: Check CUDA version
+        run: nvcc --version
+
+      - name: Build cargo-airbender and Fibonacci guest artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Build one GPU-enabled CLI binary, then reuse it for both security
+          # levels in the runtime test matrix. Build for A100 (sm_80), L4
+          # (sm_89), and H100 (sm_90), matching the self-hosted GPU fleet.
+          CUDAARCHS="80;89;90" \
+          cargo +"$RUST_TOOLCHAIN" build \
+            -p cargo-airbender \
+            --release \
+            --locked \
+            --target x86_64-unknown-linux-gnu
+
+          target/x86_64-unknown-linux-gnu/release/cargo-airbender build \
+            --project examples/fibonacci/guest \
+            -- \
+            --locked
+
+          mkdir -p artifacts/bin artifacts/fibonacci
+          cp target/x86_64-unknown-linux-gnu/release/cargo-airbender artifacts/bin/cargo-airbender
+          cp -r examples/fibonacci/guest/dist/app artifacts/fibonacci/app
+
+      - name: Upload GPU e2e artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: airbender-platform-${{ matrix.cuda }}-gpu-e2e
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 1
+
+  airbender-platform-fibonacci-gpu-e2e:
+    runs-on: [ matterlabs-ci-gpu-runner ]
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep this aligned with the build matrix because runner driver support is
+        # currently limited to CUDA 12.2 (CUDA 13 artifacts fail at runtime).
+        cuda: [ "12.9.1-devel-ubuntu22.04" ]
+        security_bits: [ "80", "100" ]
+    needs: airbender-platform-gpu-build
+    steps:
+      - name: Prepare environment
+        run: echo "/usr/local/nvidia/bin:/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@v4
+
+      - name: Check Nvidia driver version
+        run: nvidia-smi
+
+      - name: Configure low VRAM mode
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gpu_info="$(nvidia-smi --query-gpu=memory.total --format=csv,noheader)"
+          min_full_vram_mib=32768
+          low_vram_mode=0
+          while IFS=',' read -r memory; do
+            memory_mib="$(echo "$memory" | tr -dc '0-9')"
+            if [[ "$memory_mib" -lt "$min_full_vram_mib" ]]; then
+              low_vram_mode=1
+              break
+            fi
+          done <<< "$gpu_info"
+
+          if [[ "$low_vram_mode" -eq 1 ]]; then
+            echo "ZKSYNC_AIRBENDER_LOW_VRAM_MODE=1" >> "$GITHUB_ENV"
+            echo "Enabled low VRAM mode"
+          else
+            echo "Low VRAM mode is not required"
+          fi
+
+      - name: Download GPU e2e artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: airbender-platform-${{ matrix.cuda }}-gpu-e2e
+          path: airbender-gpu-e2e/
+
+      - name: Run Fibonacci through cargo-airbender
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chmod +x airbender-gpu-e2e/bin/cargo-airbender
+
+          # `Inputs::push(&10u32)` serializes to a 4-byte payload framed as two
+          # u32 words: byte length followed by the little-endian value bytes.
+          printf '00000004\n0a000000\n' > input.hex
+
+          app_bin="airbender-gpu-e2e/fibonacci/app/app.bin"
+          proof_path="output/proof-${{ matrix.security_bits }}.bin"
+          vk_path="output/vk-${{ matrix.security_bits }}.bin"
+          mkdir -p output
+
+          airbender-gpu-e2e/bin/cargo-airbender run "$app_bin" --input input.hex
+
+          airbender-gpu-e2e/bin/cargo-airbender prove "$app_bin" \
+            --input input.hex \
+            --output "$proof_path" \
+            --backend gpu \
+            --level recursion-unified \
+            --security "${{ matrix.security_bits }}"
+
+          airbender-gpu-e2e/bin/cargo-airbender generate-vk "$app_bin" \
+            --output "$vk_path" \
+            --level recursion-unified \
+            --security "${{ matrix.security_bits }}"
+
+          airbender-gpu-e2e/bin/cargo-airbender verify-proof "$proof_path" \
+            --vk "$vk_path" \
+            --expected-output 55
+
+  # Keep branch protection tied to one stable GPU check name even if we split
+  # GPU coverage across multiple jobs or matrix entries later on.
+  gpu-checks:
+    name: gpu-checks
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - airbender-platform-gpu-build
+      - airbender-platform-fibonacci-gpu-e2e
+    steps:
+      - name: Decide on GPU checks
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -147,9 +147,10 @@ jobs:
 
           chmod +x airbender-gpu-e2e/bin/cargo-airbender
 
-          # `Inputs::push(&10u32)` serializes to a 4-byte payload framed as two
-          # u32 words: byte length followed by the little-endian value bytes.
-          printf '00000004\n0a000000\n' > input.hex
+          # `Inputs::push(&10u32)` uses bincode's standard varint encoding, so
+          # the payload is one byte framed as two u32 words: byte length followed
+          # by the value byte padded to a full input word.
+          printf '00000001\n0a000000\n' > input.hex
 
           app_bin="airbender-gpu-e2e/fibonacci/app/app.bin"
           proof_path="output/proof-${{ matrix.security_bits }}.bin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -129,7 +129,7 @@ dependencies = [
  "ruint",
  "seq-macro",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "zeroize",
 ]
 
@@ -154,11 +154,12 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -589,7 +590,7 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -601,7 +602,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -657,7 +658,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -669,7 +670,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -679,7 +680,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "unroll",
@@ -692,15 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -885,7 +877,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "console"
@@ -969,15 +964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,18 +1035,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -1142,20 +1119,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1318,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -1331,7 +1298,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -1383,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -1396,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1446,7 +1413,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1554,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1646,15 +1613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1745,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1806,7 +1764,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1818,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1843,23 +1801,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1871,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1926,7 +1874,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1938,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1948,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1960,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2019,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2031,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2043,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2053,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2063,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -2369,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -2394,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -2613,7 +2561,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -2622,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -2632,7 +2580,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2876,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2896,7 +2844,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2909,7 +2857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2920,17 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -2951,7 +2889,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2963,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -3245,7 +3183,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -3259,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -3329,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -3424,7 +3362,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -3436,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -3474,7 +3412,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -3489,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -3860,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ insta = "1"
 tera = { version = "1", default-features = false }
 
 # Dependencies for airbender-crypto
-common_constants = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace", default-features = false }
-blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace", default-features = false }
+common_constants = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5", default-features = false }
+blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5", default-features = false }
 blake2 = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 k256 = { version = "0.13", default-features = false }
@@ -91,10 +91,11 @@ ark-test-curves = { version = "0.5", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 
 # Airbender dependencies
-riscv_common = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
-execution_utils = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
-gpu_prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
+riscv_common = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
+execution_utils = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
+gpu_prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
+verifier_common = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
 
 # These packages can require too much stack space to compile,
 # which can be increased with `RUST_MIN_STACK=16777216` environment variable.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You write a **guest** program (the code you want to prove) and a **host** progra
 
 **Host SDK** (`airbender-host`) - drive guest programs from native Rust:
 - Load and run RISC-V binaries
-- Generate verification keys, prove execution, verify proofs
+- Generate verification keys, choose real proof security, prove execution, verify proofs
 - Collect cycle-marker snapshots from transpiler runs
 
 ## Documentation

--- a/crates/airbender-crypto/src/sha3/delegated/mod.rs
+++ b/crates/airbender-crypto/src/sha3/delegated/mod.rs
@@ -19,14 +19,13 @@ pub(crate) use self::precompile_logic_simulator::keccak_f1600;
 
 use crate::MiniDigest;
 
-use common_constants::delegation_types::keccak_special5::KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS;
+use common_constants::delegation_types::keccak_special5::{
+    KeccakF1600State, KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS,
+};
 
-// NB: repr(align(256)) ensures that the lowest u16 of the pointer can fully address
-//     all the words without carry, s.t. we can very cheaply offset the ptr in-circuit
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-#[repr(align(256))]
-pub(crate) struct AlignedState([u64; KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS]);
+// Use Airbender's ABI type directly so the digest state layout stays coupled to
+// the delegation circuit contract exposed by `common_constants`.
+pub(crate) type AlignedState = KeccakF1600State;
 
 // NOTE: Sha3 and Keccak differ only in padding, so we can make it generic for free,
 // whether we will need it in practice or not. We also do not use a separate buffer for input,
@@ -164,7 +163,7 @@ impl<const SHA3: bool> MiniDigest for Keccak256Core<SHA3> {
     #[inline(always)]
     fn new() -> Self {
         Self {
-            state: AlignedState([0; KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS]),
+            state: AlignedState::zeroed(),
             filled_bytes: 0,
         }
     }
@@ -265,7 +264,6 @@ pub mod tests {
 
     #[allow(dead_code)]
     pub fn bad_keccak_f1600_test() {
-        use super::*;
         let state_first = [
             0xF1258F7940E1DDE7,
             0x84D5CCF933C0478A,
@@ -321,7 +319,7 @@ pub mod tests {
             0x1, //0x20D06CD26A8FBF5C,
         ];
 
-        let mut state = super::AlignedState([0; KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS]);
+        let mut state = super::AlignedState::zeroed();
         state.0[..25].copy_from_slice(&state_first);
         super::keccak_f1600(&mut state);
         assert!(state.0[..25] == state_second);
@@ -329,7 +327,6 @@ pub mod tests {
 
     #[allow(dead_code)]
     pub fn keccak_f1600_test() {
-        use super::*;
         let state_first = [
             0xF1258F7940E1DDE7,
             0x84D5CCF933C0478A,
@@ -385,7 +382,7 @@ pub mod tests {
             0x20D06CD26A8FBF5C,
         ];
 
-        let mut state = super::AlignedState([0; KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS]);
+        let mut state = super::AlignedState::zeroed();
         state.0[..25].copy_from_slice(&state_first);
         super::keccak_f1600(&mut state);
         assert!(state.0[..25] == state_second);
@@ -425,7 +422,7 @@ pub mod tests {
     #[allow(dead_code)]
     pub fn hash_chain_test() {
         use super::*;
-        let mut state = AlignedState([0; KECCAK_SPECIAL5_STATE_AND_SCRATCH_U64_WORDS]);
+        let mut state = AlignedState::zeroed();
         for _ in 0..2000 {
             super::keccak_f1600(&mut state);
         }

--- a/crates/airbender-crypto/src/sha3/delegated/precompile.rs
+++ b/crates/airbender-crypto/src/sha3/delegated/precompile.rs
@@ -2,31 +2,9 @@
 compile_error!("invalid arch - should only be compiled for RISC-V");
 
 use super::AlignedState;
-use seq_macro::seq;
 
-// TODO: eventually Rust assembly will interpolate CSR indexes
-
-use common_constants::{keccak_special5_invoke, keccak_special5_load_initial_control};
+use common_constants::delegation_types::keccak_special5;
 
 pub(crate) fn keccak_f1600(state: &mut AlignedState) {
-    unsafe {
-        // start by setting initial control
-
-        let state_ptr = state.0.as_mut_ptr();
-
-        // start by setting initial control
-        keccak_special5_load_initial_control!();
-
-        // then run 24 rounds
-        seq!(round in 0..24 {
-            // iota-theta-rho-chi-nopi: 5 iota_columnxor + 2 columnmix + 5 theta + 5 rho + 5*2 chi
-            // control flow is guarded by circuit itself
-            seq!(i in 0..27 {
-                keccak_special5_invoke!(state_ptr);
-            });
-        });
-
-        // then add +1 for the final iota
-        keccak_special5_invoke!(state_ptr);
-    }
+    keccak_special5::keccak_f1600(state);
 }

--- a/crates/airbender-host/Cargo.toml
+++ b/crates/airbender-host/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true, features = ["derive"] }
 execution_utils = { workspace = true }
 gpu_prover = { workspace = true, optional = true }
 riscv_transpiler = { workspace = true, features = ["jit", "flamegraph"] }
+verifier_common = { workspace = true }
 sha3 = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/airbender-host/README.md
+++ b/crates/airbender-host/README.md
@@ -12,6 +12,7 @@
 - `Program` for loading a packaged `dist/` directory and validating manifest hashes.
 - `Inputs` for serializing typed values or raw bytes into the canonical guest input word stream.
 - Runner, prover, and verifier builders covering transpiler execution plus dev, CPU, and GPU proving flows.
+- Runtime selection between 80-bit and 100-bit security for real proof and verification-key generation.
 - Cycle-marker utilities for profiling transpiler runs.
 
 ## Features

--- a/crates/airbender-host/src/inputs.rs
+++ b/crates/airbender-host/src/inputs.rs
@@ -72,6 +72,17 @@ mod tests {
         fs::remove_file(&file_path).expect("remove input hex file");
     }
 
+    #[test]
+    fn serializes_small_u32_as_varint_payload() {
+        let mut inputs = Inputs::new();
+        inputs.push(&10u32).expect("frame input value");
+
+        // This fixture documents the format expected by CLI and workflow input
+        // files. Bincode's standard config encodes small integers as varints, so
+        // `10u32` is a one-byte payload rather than a four-byte little-endian word.
+        assert_eq!(inputs.words(), &[1, 0x0a000000]);
+    }
+
     fn test_file_path(prefix: &str) -> PathBuf {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -1,4 +1,10 @@
 #![doc = include_str!("../README.md")]
+// TODO: This feature is not really required, but added as a workaround for:
+// https://github.com/rust-lang/rust/issues/141492
+// See also:
+// - https://github.com/rust-lang/rust/issues/144690
+// - https://github.com/rust-lang/rust/issues/133199
+#![cfg_attr(doc, feature(generic_const_exprs))]
 
 mod cycle_marker;
 mod error;

--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -8,6 +8,7 @@ mod proof;
 mod prover;
 mod receipt;
 mod runner;
+mod security;
 mod verifier;
 mod vk;
 
@@ -27,6 +28,7 @@ pub use runner::{
     resolve_cycles, ExecutionResult, FlamegraphConfig, Runner, TranspilerRunner,
     TranspilerRunnerBuilder, DEFAULT_CYCLES,
 };
+pub use security::SecurityLevel;
 pub use verifier::{
     verify_real_proof_with_vk, DevVerificationKey, DevVerifier, DevVerifierBuilder,
     RealUnifiedVerificationKey, RealUnrolledVerificationKey, RealVerifier, RealVerifierBuilder,

--- a/crates/airbender-host/src/proof.rs
+++ b/crates/airbender-host/src/proof.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use crate::prover::ProverLevel;
 use crate::receipt::Receipt;
+use crate::security::SecurityLevel;
 use sha3::Digest;
 use std::path::Path;
 
@@ -13,13 +14,26 @@ pub enum Proof {
 }
 
 impl Proof {
+    pub fn security(&self) -> SecurityLevel {
+        match self {
+            Self::Dev(proof) => proof.security,
+            Self::Real(proof) => proof.security,
+        }
+    }
+
     pub fn debug_info(&self) -> String {
         match self {
             Self::Dev(proof) => format!(
-                "dev proof: cycles={}, output={:?}",
-                proof.cycles, proof.receipt.output
+                "dev proof: security={} bits, cycles={}, output={:?}",
+                proof.security, proof.cycles, proof.receipt.output
             ),
-            Self::Real(proof) => proof.inner.debug_info(),
+            Self::Real(proof) => {
+                format!(
+                    "real proof: security={} bits, {}",
+                    proof.security,
+                    proof.inner.debug_info()
+                )
+            }
         }
     }
 }
@@ -27,6 +41,7 @@ impl Proof {
 /// Development proof emitted by the transpiler-based prover.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DevProof {
+    pub security: SecurityLevel,
     pub app_bin_hash: [u8; 32],
     pub input_words_hash: [u8; 32],
     pub receipt: Receipt,
@@ -36,16 +51,26 @@ pub struct DevProof {
 /// Real cryptographic proof emitted by CPU/GPU provers.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RealProof {
+    security: SecurityLevel,
     level: ProverLevel,
     inner: execution_utils::unrolled::UnrolledProgramProof,
 }
 
 impl RealProof {
     pub(crate) fn new(
+        security: SecurityLevel,
         level: ProverLevel,
         inner: execution_utils::unrolled::UnrolledProgramProof,
     ) -> Self {
-        Self { level, inner }
+        Self {
+            security,
+            level,
+            inner,
+        }
+    }
+
+    pub fn security(&self) -> SecurityLevel {
+        self.security
     }
 
     pub fn level(&self) -> ProverLevel {

--- a/crates/airbender-host/src/prover/cpu_prover.rs
+++ b/crates/airbender-host/src/prover/cpu_prover.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::error::{HostError, Result};
 use crate::proof::{Proof, RealProof};
 use crate::runner::{Runner, TranspilerRunnerBuilder};
+use crate::security::SecurityLevel;
 use execution_utils::setups;
 use execution_utils::unrolled;
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
@@ -63,6 +64,7 @@ pub struct CpuProverBuilder {
     worker_threads: Option<usize>,
     cycles: Option<usize>,
     ram_bound: Option<usize>,
+    security: SecurityLevel,
 }
 
 impl CpuProverBuilder {
@@ -72,6 +74,7 @@ impl CpuProverBuilder {
             worker_threads: None,
             cycles: None,
             ram_bound: None,
+            security: SecurityLevel::default(),
         }
     }
 
@@ -111,12 +114,18 @@ impl CpuProverBuilder {
         }
     }
 
+    pub fn with_security(mut self, security: SecurityLevel) -> Self {
+        self.security = security;
+        self
+    }
+
     pub fn build(self) -> Result<CpuProver> {
         CpuProver::new(
             &self.app_bin_path,
             self.worker_threads,
             self.cycles,
             self.ram_bound,
+            self.security,
         )
     }
 }
@@ -129,6 +138,7 @@ pub struct CpuProver {
     text_u32: Vec<u32>,
     cycles: Option<usize>,
     ram_bound: usize,
+    security: SecurityLevel,
     worker: execution_utils::prover_examples::prover::worker::Worker,
 }
 
@@ -138,6 +148,7 @@ impl CpuProver {
         worker_threads: Option<usize>,
         cycles: Option<usize>,
         ram_bound: Option<usize>,
+        security: SecurityLevel,
     ) -> Result<Self> {
         check_system_ram()?;
 
@@ -171,6 +182,7 @@ impl CpuProver {
             text_u32,
             cycles,
             ram_bound,
+            security,
             worker,
         })
     }
@@ -211,9 +223,14 @@ impl Prover for CpuProver {
             oracle,
             self.ram_bound,
             &self.worker,
+            self.security.into(),
         );
         let receipt = receipt_from_real_proof(&inner_proof);
-        let proof = Proof::Real(RealProof::new(super::ProverLevel::Base, inner_proof));
+        let proof = Proof::Real(RealProof::new(
+            self.security,
+            super::ProverLevel::Base,
+            inner_proof,
+        ));
 
         Ok(ProveResult {
             proof,

--- a/crates/airbender-host/src/prover/dev_prover.rs
+++ b/crates/airbender-host/src/prover/dev_prover.rs
@@ -2,6 +2,7 @@ use super::{resolve_app_bin_path, ProveResult, Prover};
 use crate::error::Result;
 use crate::proof::{hash_app_bin, hash_input_words, DevProof, Proof};
 use crate::runner::{Runner, TranspilerRunner, TranspilerRunnerBuilder};
+use crate::security::SecurityLevel;
 use std::path::{Path, PathBuf};
 
 /// Builder for creating a configured development prover.
@@ -9,6 +10,7 @@ pub struct DevProverBuilder {
     app_bin_path: PathBuf,
     cycles: Option<usize>,
     text_path: Option<PathBuf>,
+    security: SecurityLevel,
 }
 
 impl DevProverBuilder {
@@ -17,6 +19,7 @@ impl DevProverBuilder {
             app_bin_path: app_bin_path.as_ref().to_path_buf(),
             cycles: None,
             text_path: None,
+            security: SecurityLevel::default(),
         }
     }
 
@@ -37,6 +40,11 @@ impl DevProverBuilder {
         self
     }
 
+    pub fn with_security(mut self, security: SecurityLevel) -> Self {
+        self.security = security;
+        self
+    }
+
     pub fn maybe_text_path(self, text_path: Option<impl AsRef<Path>>) -> Self {
         match text_path {
             Some(v) => self.with_text_path(v),
@@ -45,18 +53,29 @@ impl DevProverBuilder {
     }
 
     pub fn build(self) -> Result<DevProver> {
-        DevProver::new(&self.app_bin_path, self.cycles, self.text_path.as_deref())
+        DevProver::new(
+            &self.app_bin_path,
+            self.cycles,
+            self.text_path.as_deref(),
+            self.security,
+        )
     }
 }
 
 /// Development prover that records transpiler execution metadata instead of generating a zk-proof.
 pub struct DevProver {
+    security: SecurityLevel,
     app_bin_hash: [u8; 32],
     runner: TranspilerRunner,
 }
 
 impl DevProver {
-    fn new(app_bin_path: &Path, cycles: Option<usize>, text_path: Option<&Path>) -> Result<Self> {
+    fn new(
+        app_bin_path: &Path,
+        cycles: Option<usize>,
+        text_path: Option<&Path>,
+        security: SecurityLevel,
+    ) -> Result<Self> {
         let app_bin_path = resolve_app_bin_path(app_bin_path)?;
         let app_bin_hash = hash_app_bin(&app_bin_path)?;
 
@@ -66,6 +85,7 @@ impl DevProver {
             .build()?;
 
         Ok(Self {
+            security,
             app_bin_hash,
             runner,
         })
@@ -79,6 +99,7 @@ impl Prover for DevProver {
         let receipt = execution.receipt;
 
         let proof = Proof::Dev(DevProof {
+            security: self.security,
             app_bin_hash: self.app_bin_hash,
             input_words_hash: hash_input_words(input_words),
             receipt: receipt.clone(),

--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -3,6 +3,7 @@ use super::{
 };
 use crate::error::{HostError, Result};
 use crate::proof::{Proof, RealProof};
+use crate::security::SecurityLevel;
 use execution_utils::unrolled_gpu::UnrolledProver;
 use gpu_prover::execution::prover::ExecutionProverConfiguration;
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
@@ -16,6 +17,7 @@ use std::thread::JoinHandle;
 pub struct GpuProverBuilder {
     app_bin_path: PathBuf,
     worker_threads: Option<usize>,
+    security: SecurityLevel,
     level: ProverLevel,
 }
 
@@ -24,6 +26,7 @@ impl GpuProverBuilder {
         Self {
             app_bin_path: app_bin_path.as_ref().to_path_buf(),
             worker_threads: None,
+            security: SecurityLevel::default(),
             level: ProverLevel::RecursionUnified,
         }
     }
@@ -45,8 +48,18 @@ impl GpuProverBuilder {
         self
     }
 
+    pub fn with_security(mut self, security: SecurityLevel) -> Self {
+        self.security = security;
+        self
+    }
+
     pub fn build(self) -> Result<GpuProver> {
-        GpuProver::new(&self.app_bin_path, self.worker_threads, self.level)
+        GpuProver::new(
+            &self.app_bin_path,
+            self.worker_threads,
+            self.security,
+            self.level,
+        )
     }
 }
 
@@ -76,7 +89,12 @@ enum WorkerCommand {
 }
 
 impl GpuProver {
-    fn new(app_bin_path: &Path, worker_threads: Option<usize>, level: ProverLevel) -> Result<Self> {
+    fn new(
+        app_bin_path: &Path,
+        worker_threads: Option<usize>,
+        security: SecurityLevel,
+        level: ProverLevel,
+    ) -> Result<Self> {
         if matches!(worker_threads, Some(0)) {
             return Err(HostError::Prover(
                 "worker thread count must be greater than zero".to_string(),
@@ -84,7 +102,8 @@ impl GpuProver {
         }
 
         let app_bin_path = resolve_app_bin_path(app_bin_path)?;
-        let (command_tx, worker_handle) = spawn_worker(app_bin_path, worker_threads, level)?;
+        let (command_tx, worker_handle) =
+            spawn_worker(app_bin_path, worker_threads, security, level)?;
 
         Ok(Self {
             command_tx,
@@ -168,6 +187,7 @@ impl Drop for GpuProver {
 fn spawn_worker(
     app_bin_path: PathBuf,
     worker_threads: Option<usize>,
+    security: SecurityLevel,
     level: ProverLevel,
 ) -> Result<(mpsc::Sender<WorkerCommand>, JoinHandle<()>)> {
     let (command_tx, command_rx) = mpsc::channel();
@@ -175,7 +195,16 @@ fn spawn_worker(
 
     let worker_handle = std::thread::Builder::new()
         .name("airbender-gpu-prover".to_string())
-        .spawn(move || gpu_worker_loop(command_rx, init_tx, app_bin_path, worker_threads, level))
+        .spawn(move || {
+            gpu_worker_loop(
+                command_rx,
+                init_tx,
+                app_bin_path,
+                worker_threads,
+                security,
+                level,
+            )
+        })
         .map_err(|err| {
             HostError::Prover(format!("failed to spawn GPU prover worker thread: {err}"))
         })?;
@@ -204,18 +233,23 @@ fn gpu_worker_loop(
     init_tx: mpsc::Sender<Result<()>>,
     app_bin_path: PathBuf,
     worker_threads: Option<usize>,
+    security: SecurityLevel,
     level: ProverLevel,
 ) {
     // Keep all prover state inside this dedicated thread so a panic does not unwind
     // through host-call boundaries or require `AssertUnwindSafe`.
-    let prover =
-        match create_unrolled_prover(&app_bin_path, worker_threads, level.as_unrolled_level()) {
-            Ok(prover) => prover,
-            Err(err) => {
-                let _ = init_tx.send(Err(err));
-                return;
-            }
-        };
+    let prover = match create_unrolled_prover(
+        &app_bin_path,
+        worker_threads,
+        security,
+        level.as_unrolled_level(),
+    ) {
+        Ok(prover) => prover,
+        Err(err) => {
+            let _ = init_tx.send(Err(err));
+            return;
+        }
+    };
 
     if init_tx.send(Ok(())).is_err() {
         return;
@@ -231,7 +265,7 @@ fn gpu_worker_loop(
                 // TODO: we use `batch 0` for all the jobs, which can cause issues when generating multiple proofs in parallel.
                 let (inner_proof, cycles) = prover.prove(0, oracle);
                 let receipt = receipt_from_real_proof(&inner_proof);
-                let proof = Proof::Real(RealProof::new(level, inner_proof));
+                let proof = Proof::Real(RealProof::new(security, level, inner_proof));
                 let result = Ok(ProveResult {
                     proof,
                     cycles,
@@ -258,6 +292,7 @@ fn panic_payload_to_string(payload: Box<dyn Any + Send + 'static>) -> String {
 fn create_unrolled_prover(
     app_bin_path: &Path,
     worker_threads: Option<usize>,
+    security: SecurityLevel,
     level: execution_utils::unrolled_gpu::UnrolledProverLevel,
 ) -> Result<UnrolledProver> {
     let base_path = base_path(app_bin_path)?;
@@ -266,5 +301,10 @@ fn create_unrolled_prover(
         configuration.max_thread_pool_threads = Some(threads);
         configuration.replay_worker_threads_count = threads;
     }
-    Ok(UnrolledProver::new(&base_path, configuration, level))
+    Ok(UnrolledProver::new(
+        security.into(),
+        &base_path,
+        configuration,
+        level,
+    ))
 }

--- a/crates/airbender-host/src/security.rs
+++ b/crates/airbender-host/src/security.rs
@@ -1,0 +1,40 @@
+/// Cryptographic security target for real Airbender proofs.
+///
+/// Airbender exposes 80-bit and 100-bit security as independent proving modes.
+/// The host SDK keeps that choice explicit in the proof and verification-key
+/// envelopes so callers cannot accidentally verify a proof with artifacts built
+/// for a different security target.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum SecurityLevel {
+    /// Use the 80-bit security configuration.
+    Bits80,
+    /// Use the 100-bit security configuration.
+    #[default]
+    Bits100,
+}
+
+impl SecurityLevel {
+    pub fn bits(self) -> u16 {
+        match self {
+            Self::Bits80 => 80,
+            Self::Bits100 => 100,
+        }
+    }
+}
+
+impl From<SecurityLevel> for verifier_common::SecurityModel {
+    fn from(security: SecurityLevel) -> Self {
+        match security {
+            SecurityLevel::Bits80 => Self::Security80,
+            SecurityLevel::Bits100 => Self::Security100,
+        }
+    }
+}
+
+impl std::fmt::Display for SecurityLevel {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.bits())
+    }
+}

--- a/crates/airbender-host/src/verifier.rs
+++ b/crates/airbender-host/src/verifier.rs
@@ -1,6 +1,7 @@
 use crate::error::{HostError, Result};
 use crate::proof::{hash_app_bin, hash_input_words, Proof, RealProof};
 use crate::prover::ProverLevel;
+use crate::security::SecurityLevel;
 use crate::vk::{
     compute_unified_vk, compute_unrolled_vk, verify_proof, verify_unrolled_proof, UnifiedVk,
     UnrolledVk,
@@ -16,9 +17,20 @@ pub enum VerificationKey {
     RealUnrolled(RealUnrolledVerificationKey),
 }
 
+impl VerificationKey {
+    pub fn security(&self) -> SecurityLevel {
+        match self {
+            Self::Dev(vk) => vk.security,
+            Self::RealUnified(vk) => vk.vk.security,
+            Self::RealUnrolled(vk) => vk.vk.security,
+        }
+    }
+}
+
 /// Development verification key.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DevVerificationKey {
+    pub security: SecurityLevel,
     pub app_bin_hash: [u8; 32],
 }
 
@@ -78,7 +90,7 @@ impl<'a> VerificationRequest<'a> {
 
 /// Verifier interface shared by dev and real verifiers.
 pub trait Verifier {
-    fn generate_vk(&self) -> Result<VerificationKey>;
+    fn generate_vk(&self, security: SecurityLevel) -> Result<VerificationKey>;
 
     fn verify(
         &self,
@@ -135,13 +147,18 @@ impl DevVerifier {
         let app_bin_hash = hash_app_bin(&app_bin_path)?;
         Ok(Self { app_bin_hash })
     }
+
+    pub fn generate_vk(&self, security: SecurityLevel) -> Result<VerificationKey> {
+        Ok(VerificationKey::Dev(DevVerificationKey {
+            security,
+            app_bin_hash: self.app_bin_hash,
+        }))
+    }
 }
 
 impl Verifier for DevVerifier {
-    fn generate_vk(&self) -> Result<VerificationKey> {
-        Ok(VerificationKey::Dev(DevVerificationKey {
-            app_bin_hash: self.app_bin_hash,
-        }))
+    fn generate_vk(&self, security: SecurityLevel) -> Result<VerificationKey> {
+        DevVerifier::generate_vk(self, security)
     }
 
     fn verify(
@@ -166,6 +183,8 @@ impl Verifier for DevVerifier {
                 ));
             }
         };
+
+        ensure_proof_vk_security_matches(proof.security, vk.security)?;
 
         if vk.app_bin_hash != self.app_bin_hash {
             return Err(HostError::Verification(
@@ -221,25 +240,29 @@ impl RealVerifier {
             level,
         })
     }
-}
 
-impl Verifier for RealVerifier {
-    fn generate_vk(&self) -> Result<VerificationKey> {
+    pub fn generate_vk(&self, security: SecurityLevel) -> Result<VerificationKey> {
         match self.level {
             ProverLevel::RecursionUnified => {
-                let vk = compute_unified_vk(&self.app_bin_path)?;
+                let vk = compute_unified_vk(&self.app_bin_path, security)?;
                 Ok(VerificationKey::RealUnified(RealUnifiedVerificationKey {
                     vk,
                 }))
             }
             ProverLevel::Base | ProverLevel::RecursionUnrolled => {
-                let vk = compute_unrolled_vk(&self.app_bin_path, self.level)?;
+                let vk = compute_unrolled_vk(&self.app_bin_path, self.level, security)?;
                 Ok(VerificationKey::RealUnrolled(RealUnrolledVerificationKey {
                     level: self.level,
                     vk,
                 }))
             }
         }
+    }
+}
+
+impl Verifier for RealVerifier {
+    fn generate_vk(&self, security: SecurityLevel) -> Result<VerificationKey> {
+        RealVerifier::generate_vk(self, security)
     }
 
     fn verify(
@@ -267,12 +290,15 @@ impl Verifier for RealVerifier {
             (
                 ProverLevel::RecursionUnified,
                 VerificationKey::RealUnified(RealUnifiedVerificationKey { vk }),
-            ) => verify_proof(
-                proof.inner(),
-                vk,
-                Some(self.app_bin_hash),
-                request.expected_output(),
-            ),
+            ) => {
+                ensure_proof_vk_security_matches(proof.security(), vk.security)?;
+                verify_proof(
+                    proof.inner(),
+                    vk,
+                    Some(self.app_bin_hash),
+                    request.expected_output(),
+                )
+            }
             (
                 ProverLevel::Base | ProverLevel::RecursionUnrolled,
                 VerificationKey::RealUnrolled(RealUnrolledVerificationKey { level, vk }),
@@ -284,6 +310,7 @@ impl Verifier for RealVerifier {
                         level
                     )));
                 }
+                ensure_proof_vk_security_matches(proof.security(), vk.security)?;
 
                 verify_unrolled_proof(
                     proof.inner(),
@@ -324,7 +351,10 @@ pub fn verify_real_proof_with_vk(
         (
             ProverLevel::RecursionUnified,
             VerificationKey::RealUnified(RealUnifiedVerificationKey { vk }),
-        ) => verify_proof(proof.inner(), vk, None, expected_output),
+        ) => {
+            ensure_proof_vk_security_matches(proof.security(), vk.security)?;
+            verify_proof(proof.inner(), vk, None, expected_output)
+        }
         (
             ProverLevel::Base | ProverLevel::RecursionUnrolled,
             VerificationKey::RealUnrolled(RealUnrolledVerificationKey { level, vk }),
@@ -336,6 +366,7 @@ pub fn verify_real_proof_with_vk(
                     level
                 )));
             }
+            ensure_proof_vk_security_matches(proof.security(), vk.security)?;
 
             verify_unrolled_proof(proof.inner(), vk, proof.level(), None, expected_output)
         }
@@ -353,6 +384,19 @@ pub fn verify_real_proof_with_vk(
             ))
         }
     }
+}
+
+fn ensure_proof_vk_security_matches(
+    proof_security: SecurityLevel,
+    vk_security: SecurityLevel,
+) -> Result<()> {
+    if proof_security != vk_security {
+        return Err(HostError::Verification(format!(
+            "proof security {} bits does not match verification key security {} bits",
+            proof_security, vk_security
+        )));
+    }
+    Ok(())
 }
 
 fn resolve_app_bin_path(path: &Path) -> Result<PathBuf> {
@@ -380,4 +424,42 @@ fn resolve_app_bin_path(path: &Path) -> Result<PathBuf> {
         "binary not found: {}",
         path.display()
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proof::DevProof;
+    use crate::receipt::Receipt;
+
+    #[test]
+    fn dev_verifier_rejects_security_mismatch() {
+        let app_bin_hash = [7u8; 32];
+        let input_words = [1u32, 10u32];
+        let receipt = receipt_with_output(55);
+        let proof = Proof::Dev(DevProof {
+            security: SecurityLevel::Bits100,
+            app_bin_hash,
+            input_words_hash: hash_input_words(&input_words),
+            receipt,
+            cycles: 100,
+        });
+        let vk = VerificationKey::Dev(DevVerificationKey {
+            security: SecurityLevel::Bits80,
+            app_bin_hash,
+        });
+        let verifier = DevVerifier { app_bin_hash };
+
+        let err = verifier
+            .verify(&proof, &vk, VerificationRequest::dev(&input_words, &55u32))
+            .expect_err("mismatched dev proof/VK security must fail verification");
+
+        assert!(err.to_string().contains("proof security 100 bits"));
+    }
+
+    fn receipt_with_output(output: u32) -> Receipt {
+        let mut registers = [0u32; 32];
+        registers[10] = output;
+        Receipt::from_registers(registers)
+    }
 }

--- a/crates/airbender-host/src/vk.rs
+++ b/crates/airbender-host/src/vk.rs
@@ -1,5 +1,6 @@
 use crate::error::{HostError, Result};
 use crate::prover::ProverLevel;
+use crate::security::SecurityLevel;
 use airbender_core::guest::Commit;
 use execution_utils::setups;
 use execution_utils::unified_circuit::verify_proof_in_unified_layer;
@@ -17,6 +18,7 @@ use std::path::{Path, PathBuf};
 /// Unified verification key bundle for recursion.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct UnifiedVk {
+    pub security: SecurityLevel,
     pub app_bin_hash: [u8; 32],
     pub unified_setup: UnrolledProgramSetup,
     pub unified_layouts: setups::CompiledCircuitsSet,
@@ -25,15 +27,16 @@ pub struct UnifiedVk {
 /// Unrolled verification key bundle for base or recursion-unrolled layers.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct UnrolledVk {
+    pub security: SecurityLevel,
     pub app_bin_hash: [u8; 32],
     pub setup: UnrolledProgramSetup,
     pub compiled_layouts: setups::CompiledCircuitsSet,
 }
 
-pub fn compute_unified_vk(app_bin_path: &Path) -> Result<UnifiedVk> {
+pub fn compute_unified_vk(app_bin_path: &Path, security: SecurityLevel) -> Result<UnifiedVk> {
     #[cfg(not(feature = "gpu-prover"))]
     {
-        let _ = app_bin_path;
+        let _ = (app_bin_path, security);
         return Err(HostError::Verification(
             "recursion-unified verification key generation requires the `gpu-prover` feature"
                 .to_string(),
@@ -45,10 +48,23 @@ pub fn compute_unified_vk(app_bin_path: &Path) -> Result<UnifiedVk> {
         let app_bin_hash = hash_app_bin(app_bin_path)?;
 
         // TODO: cache unified setup/layout artifacts on disk to avoid recomputing on every run.
-        let (binary, binary_u32) =
-            setups::pad_binary(execution_utils::unrolled_gpu::RECURSION_UNIFIED_BIN.to_vec());
-        let (text, _) =
-            setups::pad_binary(execution_utils::unrolled_gpu::RECURSION_UNIFIED_TXT.to_vec());
+        let security_model = security.into();
+        let (binary, binary_u32) = setups::pad_binary(
+            execution_utils::verifier_binaries::recursion_artifact(
+                security_model,
+                execution_utils::RecursionLayer::Unified,
+                execution_utils::RecursionArtifact::Bin,
+            )
+            .to_vec(),
+        );
+        let (text, _) = setups::pad_binary(
+            execution_utils::verifier_binaries::recursion_artifact(
+                security_model,
+                execution_utils::RecursionLayer::Unified,
+                execution_utils::RecursionArtifact::Txt,
+            )
+            .to_vec(),
+        );
 
         let unified_setup =
             execution_utils::unified_circuit::compute_unified_setup_for_machine_configuration::<
@@ -60,6 +76,7 @@ pub fn compute_unified_vk(app_bin_path: &Path) -> Result<UnifiedVk> {
             >(&binary_u32);
 
         Ok(UnifiedVk {
+            security,
             app_bin_hash,
             unified_setup,
             unified_layouts,
@@ -67,7 +84,11 @@ pub fn compute_unified_vk(app_bin_path: &Path) -> Result<UnifiedVk> {
     }
 }
 
-pub fn compute_unrolled_vk(app_bin_path: &Path, level: ProverLevel) -> Result<UnrolledVk> {
+pub fn compute_unrolled_vk(
+    app_bin_path: &Path,
+    level: ProverLevel,
+    security: SecurityLevel,
+) -> Result<UnrolledVk> {
     if level == ProverLevel::RecursionUnified {
         return Err(HostError::Verification(
             "unified verification keys must be generated with compute_unified_vk".to_string(),
@@ -95,11 +116,22 @@ pub fn compute_unrolled_vk(app_bin_path: &Path, level: ProverLevel) -> Result<Un
 
             #[cfg(feature = "gpu-prover")]
             {
+                let security_model = security.into();
                 let (binary, binary_u32) = setups::pad_binary(
-                    execution_utils::unrolled_gpu::RECURSION_UNROLLED_BIN.to_vec(),
+                    execution_utils::verifier_binaries::recursion_artifact(
+                        security_model,
+                        execution_utils::RecursionLayer::Unrolled,
+                        execution_utils::RecursionArtifact::Bin,
+                    )
+                    .to_vec(),
                 );
                 let (text, _) = setups::pad_binary(
-                    execution_utils::unrolled_gpu::RECURSION_UNROLLED_TXT.to_vec(),
+                    execution_utils::verifier_binaries::recursion_artifact(
+                        security_model,
+                        execution_utils::RecursionLayer::Unrolled,
+                        execution_utils::RecursionArtifact::Txt,
+                    )
+                    .to_vec(),
                 );
                 (binary, binary_u32, text)
             }
@@ -138,6 +170,7 @@ pub fn compute_unrolled_vk(app_bin_path: &Path, level: ProverLevel) -> Result<Un
     };
 
     Ok(UnrolledVk {
+        security,
         app_bin_hash,
         setup,
         compiled_layouts,
@@ -152,9 +185,14 @@ pub fn verify_proof(
 ) -> Result<()> {
     verify_app_bin_hash(expected_app_bin_hash, vk.app_bin_hash)?;
 
-    let verifier_output =
-        verify_proof_in_unified_layer(proof, &vk.unified_setup, &vk.unified_layouts, false)
-            .map_err(|_| HostError::Verification("proof verification failed".to_string()))?;
+    let verifier_output = verify_proof_in_unified_layer(
+        proof,
+        &vk.unified_setup,
+        &vk.unified_layouts,
+        false,
+        vk.security.into(),
+    )
+    .map_err(|_| HostError::Verification("proof verification failed".to_string()))?;
     verify_expected_output(expected_output, verifier_output)?;
     Ok(())
 }
@@ -179,9 +217,14 @@ pub fn verify_unrolled_proof(
         }
     };
 
-    let verifier_output =
-        verify_unrolled_layer_proof(proof, &vk.setup, &vk.compiled_layouts, is_base_layer)
-            .map_err(|_| HostError::Verification("proof verification failed".to_string()))?;
+    let verifier_output = verify_unrolled_layer_proof(
+        proof,
+        &vk.setup,
+        &vk.compiled_layouts,
+        is_base_layer,
+        vk.security.into(),
+    )
+    .map_err(|_| HostError::Verification("proof verification failed".to_string()))?;
     verify_expected_output(expected_output, verifier_output)?;
     Ok(())
 }

--- a/crates/cargo-airbender/README.md
+++ b/crates/cargo-airbender/README.md
@@ -12,7 +12,7 @@
 - `new`: create a host + guest template project.
 - `build`: compile a guest and package a `dist/` bundle.
 - `run` and `flamegraph`: execute guest binaries through the transpiler.
-- `prove`, `generate-vk`, and `verify-proof`: work with dev, CPU, or GPU proof flows.
+- `prove`, `generate-vk`, and `verify-proof`: work with dev, CPU, or GPU proof flows, including 80-bit or 100-bit real proof security.
 - `clean`: remove Docker resources created by reproducible builds.
 
 ## Installation

--- a/crates/cargo-airbender/src/cli.rs
+++ b/crates/cargo-airbender/src/cli.rs
@@ -178,6 +178,13 @@ pub struct ProveArgs {
     pub ram_bound: Option<usize>,
     #[arg(long, value_enum, default_value_t = ProverLevelArg::RecursionUnified)]
     pub level: ProverLevelArg,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = SecurityLevelArg::default(),
+        help = "Security level recorded in proof artifacts (80 or 100 bits; default: 100)"
+    )]
+    pub security: SecurityLevelArg,
 }
 
 #[derive(Args, Debug)]
@@ -187,6 +194,13 @@ pub struct GenerateVkArgs {
     pub output: PathBuf,
     #[arg(long, value_enum, default_value_t = ProverLevelArg::RecursionUnified)]
     pub level: ProverLevelArg,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = SecurityLevelArg::default(),
+        help = "Security level for verification keys (80 or 100 bits; default: 100)"
+    )]
+    pub security: SecurityLevelArg,
 }
 
 #[derive(Args, Debug)]
@@ -214,6 +228,45 @@ pub enum ProverLevelArg {
     Base,
     RecursionUnrolled,
     RecursionUnified,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecurityLevelArg {
+    #[value(name = "80")]
+    Bits80,
+    #[value(name = "100")]
+    Bits100,
+}
+
+impl Default for SecurityLevelArg {
+    fn default() -> Self {
+        Self::from(airbender_host::SecurityLevel::default())
+    }
+}
+
+impl From<airbender_host::SecurityLevel> for SecurityLevelArg {
+    fn from(security: airbender_host::SecurityLevel) -> Self {
+        match security {
+            airbender_host::SecurityLevel::Bits80 => Self::Bits80,
+            airbender_host::SecurityLevel::Bits100 => Self::Bits100,
+        }
+    }
+}
+
+impl From<SecurityLevelArg> for airbender_host::SecurityLevel {
+    fn from(security: SecurityLevelArg) -> Self {
+        match security {
+            SecurityLevelArg::Bits80 => Self::Bits80,
+            SecurityLevelArg::Bits100 => Self::Bits100,
+        }
+    }
+}
+
+impl std::fmt::Display for SecurityLevelArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let host_security = airbender_host::SecurityLevel::from(*self);
+        write!(formatter, "{host_security}")
+    }
 }
 
 #[cfg(test)]
@@ -436,5 +489,95 @@ mod tests {
         .expect_err("repeated expected-output flag should fail");
 
         assert!(err.to_string().contains("cannot be used multiple times"));
+    }
+
+    #[test]
+    fn parse_prove_security_100() {
+        let cli = Cli::parse_from([
+            "cargo-airbender",
+            "prove",
+            "app.bin",
+            "--input",
+            "input.hex",
+            "--output",
+            "proof.bin",
+            "--backend",
+            "gpu",
+            "--security",
+            "100",
+        ]);
+        match cli.command {
+            Commands::Prove(args) => {
+                assert_eq!(args.security, SecurityLevelArg::Bits100);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_prove_security_defaults_to_100() {
+        let cli = Cli::parse_from([
+            "cargo-airbender",
+            "prove",
+            "app.bin",
+            "--input",
+            "input.hex",
+            "--output",
+            "proof.bin",
+            "--backend",
+            "gpu",
+        ]);
+        match cli.command {
+            Commands::Prove(args) => {
+                assert_eq!(args.security, SecurityLevelArg::Bits100);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_generate_vk_security_80() {
+        let cli = Cli::parse_from([
+            "cargo-airbender",
+            "generate-vk",
+            "app.bin",
+            "--security",
+            "80",
+        ]);
+        match cli.command {
+            Commands::GenerateVk(args) => {
+                assert_eq!(args.security, SecurityLevelArg::Bits80);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_generate_vk_security_defaults_to_100() {
+        let cli = Cli::parse_from(["cargo-airbender", "generate-vk", "app.bin"]);
+        match cli.command {
+            Commands::GenerateVk(args) => {
+                assert_eq!(args.security, SecurityLevelArg::Bits100);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_prove_rejects_invalid_security() {
+        let err = Cli::try_parse_from([
+            "cargo-airbender",
+            "prove",
+            "app.bin",
+            "--input",
+            "input.hex",
+            "--output",
+            "proof.bin",
+            "--security",
+            "90",
+        ])
+        .expect_err("invalid security should fail");
+
+        assert!(err.to_string().contains("invalid value"));
     }
 }

--- a/crates/cargo-airbender/src/commands/new/snapshots/cargo_airbender__commands__new__tests__new_gpu_backend_generates_real_prover_setup.snap
+++ b/crates/cargo-airbender/src/commands/new/snapshots/cargo_airbender__commands__new__tests__new_gpu_backend_generates_real_prover_setup.snap
@@ -63,7 +63,8 @@ debug = 0
 debug = 0
 === host/src/main.rs ===
 use airbender_host::{
-    Inputs, Program, Prover, ProverLevel, Result, Runner, VerificationRequest, Verifier,
+    Inputs, Program, Prover, ProverLevel, Result, Runner, SecurityLevel, VerificationRequest,
+    Verifier,
 };
 use std::path::PathBuf;
 
@@ -90,8 +91,10 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    let security = SecurityLevel::default();
     let prover = program
         .gpu_prover()
+        .with_security(security)
         .with_level(ProverLevel::RecursionUnified)
         .build()?;
     let prove_result = prover.prove(inputs.words())?;
@@ -107,7 +110,7 @@ fn main() -> Result<()> {
 
     let expected_output = 42u32;
     let verifier = program.real_verifier(ProverLevel::RecursionUnified).build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/crates/cargo-airbender/src/commands/new/snapshots/cargo_airbender__commands__new__tests__new_scaffolds_host_and_guest.snap
+++ b/crates/cargo-airbender/src/commands/new/snapshots/cargo_airbender__commands__new__tests__new_scaffolds_host_and_guest.snap
@@ -109,7 +109,9 @@ debug = 0
 [toolchain]
 channel = "nightly-2026-02-10"
 === host/src/main.rs ===
-use airbender_host::{Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
@@ -135,7 +137,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     let proof_output = prove_result.receipt.output[0];
     println!(
@@ -149,7 +152,7 @@ fn main() -> Result<()> {
 
     let expected_output = 42u32;
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/crates/cargo-airbender/src/commands/prove.rs
+++ b/crates/cargo-airbender/src/commands/prove.rs
@@ -6,6 +6,7 @@ use airbender_host::Prover;
 
 pub fn run(args: ProveArgs) -> Result<()> {
     let input_words = input::parse_input_words(&args.input)?;
+    let security = args.security;
 
     let prove_result = match args.backend {
         ProverBackendArg::Dev => {
@@ -19,7 +20,9 @@ pub fn run(args: ProveArgs) -> Result<()> {
                 tracing::warn!("ignoring `--level` for dev backend");
             }
 
+            let security = security.into();
             let prover = airbender_host::DevProverBuilder::new(&args.app_bin)
+                .with_security(security)
                 .maybe_cycles(args.cycles)
                 .build()
                 .map_err(|err| {
@@ -45,8 +48,10 @@ pub fn run(args: ProveArgs) -> Result<()> {
             #[cfg(feature = "gpu-prover")]
             {
                 let level = as_host_level(args.level);
+                let security = security.into();
                 let prover = airbender_host::GpuProverBuilder::new(&args.app_bin)
                     .with_level(level)
+                    .with_security(security)
                     .maybe_worker_threads(args.threads)
                     .build()
                     .map_err(|err| {
@@ -74,6 +79,7 @@ pub fn run(args: ProveArgs) -> Result<()> {
         }
         ProverBackendArg::Cpu => {
             let level = as_host_level(args.level);
+            let security = security.into();
             if level != airbender_host::ProverLevel::Base {
                 return Err(
                     CliError::new("CPU backend currently supports only `--level base`")
@@ -82,6 +88,7 @@ pub fn run(args: ProveArgs) -> Result<()> {
             }
 
             let prover = airbender_host::CpuProverBuilder::new(&args.app_bin)
+                .with_security(security)
                 .maybe_worker_threads(args.threads)
                 .maybe_cycles(args.cycles)
                 .maybe_ram_bound(args.ram_bound)
@@ -121,6 +128,7 @@ pub fn run(args: ProveArgs) -> Result<()> {
     ui::success("proof generated");
     ui::field("backend", backend_name(args.backend));
     ui::field("level", proof_level(args.backend, args.level));
+    ui::field("security", security);
     ui::field("cycles", prove_result.cycles);
     ui::field("output", args.output.display());
 

--- a/crates/cargo-airbender/src/commands/vk.rs
+++ b/crates/cargo-airbender/src/commands/vk.rs
@@ -6,33 +6,38 @@ use std::path::Path;
 
 pub fn generate(args: GenerateVkArgs) -> Result<()> {
     ensure_gpu_vk_support()?;
+    let security = args.security;
+    let host_security = security.into();
 
     let vk = match args.level {
         ProverLevelArg::RecursionUnified => {
-            let vk = airbender_host::compute_unified_vk(&args.app_bin).map_err(|err| {
-                CliError::with_source(
-                    format!(
-                        "failed to compute unified verification keys for `{}`",
-                        args.app_bin.display()
-                    ),
-                    err,
-                )
-            })?;
+            let vk = airbender_host::compute_unified_vk(&args.app_bin, host_security).map_err(
+                |err| {
+                    CliError::with_source(
+                        format!(
+                            "failed to compute unified verification keys for `{}`",
+                            args.app_bin.display()
+                        ),
+                        err,
+                    )
+                },
+            )?;
             airbender_host::VerificationKey::RealUnified(
                 airbender_host::RealUnifiedVerificationKey { vk },
             )
         }
         ProverLevelArg::Base | ProverLevelArg::RecursionUnrolled => {
             let level = as_host_level(args.level);
-            let vk = airbender_host::compute_unrolled_vk(&args.app_bin, level).map_err(|err| {
-                CliError::with_source(
-                    format!(
-                        "failed to compute unrolled verification keys for `{}`",
-                        args.app_bin.display()
-                    ),
-                    err,
-                )
-            })?;
+            let vk = airbender_host::compute_unrolled_vk(&args.app_bin, level, host_security)
+                .map_err(|err| {
+                    CliError::with_source(
+                        format!(
+                            "failed to compute unrolled verification keys for `{}`",
+                            args.app_bin.display()
+                        ),
+                        err,
+                    )
+                })?;
             airbender_host::VerificationKey::RealUnrolled(
                 airbender_host::RealUnrolledVerificationKey { level, vk },
             )
@@ -43,6 +48,7 @@ pub fn generate(args: GenerateVkArgs) -> Result<()> {
 
     ui::success("verification keys generated");
     ui::field("level", level_name(args.level));
+    ui::field("security", security);
     ui::field("output", args.output.display());
 
     Ok(())
@@ -85,7 +91,7 @@ pub fn verify(args: VerifyProofArgs) -> Result<()> {
         )
     })?;
 
-    let level = match &proof {
+    let (level, security) = match &proof {
         airbender_host::Proof::Dev(_) => {
             return Err(CliError::new(
                 "detected a dev proof; `cargo airbender verify-proof` supports only real proofs",
@@ -101,7 +107,7 @@ pub fn verify(args: VerifyProofArgs) -> Result<()> {
 
             airbender_host::verify_real_proof_with_vk(proof, &vk, expected_output_commit)
                 .map_err(|err| CliError::with_source("proof verification failed", err))?;
-            proof.level()
+            (proof.level(), proof.security())
         }
     };
 
@@ -111,6 +117,7 @@ pub fn verify(args: VerifyProofArgs) -> Result<()> {
 
     ui::success("proof verified");
     ui::field("level", host_level_name(level));
+    ui::field("security", security);
     if let Some(words) = expected_output_words {
         ui::field("expected_output", format_output_words(&words));
     }
@@ -253,7 +260,7 @@ fn write_bincode<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 mod tests {
     use super::*;
     #[cfg(not(feature = "gpu-prover"))]
-    use crate::cli::GenerateVkArgs;
+    use crate::cli::{GenerateVkArgs, SecurityLevelArg};
     #[cfg(not(feature = "gpu-prover"))]
     use std::path::PathBuf;
 
@@ -264,6 +271,7 @@ mod tests {
             app_bin: PathBuf::from("app.bin"),
             output: PathBuf::from("vk.bin"),
             level: ProverLevelArg::Base,
+            security: SecurityLevelArg::default(),
         })
         .expect_err("generate-vk must require gpu-prover support");
 

--- a/crates/cargo-airbender/src/main.rs
+++ b/crates/cargo-airbender/src/main.rs
@@ -1,4 +1,10 @@
 #![doc = include_str!("../README.md")]
+// TODO: This feature is not really required, but added as a workaround for:
+// https://github.com/rust-lang/rust/issues/141492
+// See also:
+// - https://github.com/rust-lang/rust/issues/144690
+// - https://github.com/rust-lang/rust/issues/133199
+#![cfg_attr(doc, feature(generic_const_exprs))]
 
 mod cli;
 mod commands;

--- a/crates/cargo-airbender/templates/host/src/main.dev.rs.template
+++ b/crates/cargo-airbender/templates/host/src/main.dev.rs.template
@@ -1,4 +1,6 @@
-use airbender_host::{Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
@@ -24,7 +26,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     let proof_output = prove_result.receipt.output[0];
     println!(
@@ -38,7 +41,7 @@ fn main() -> Result<()> {
 
     let expected_output = 42u32;
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/crates/cargo-airbender/templates/host/src/main.gpu.rs.template
+++ b/crates/cargo-airbender/templates/host/src/main.gpu.rs.template
@@ -1,5 +1,6 @@
 use airbender_host::{
-    Inputs, Program, Prover, ProverLevel, Result, Runner, VerificationRequest, Verifier,
+    Inputs, Program, Prover, ProverLevel, Result, Runner, SecurityLevel, VerificationRequest,
+    Verifier,
 };
 use std::path::PathBuf;
 
@@ -26,8 +27,10 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    let security = SecurityLevel::default();
     let prover = program
         .gpu_prover()
+        .with_security(security)
         .with_level(ProverLevel::RecursionUnified)
         .build()?;
     let prove_result = prover.prove(inputs.words())?;
@@ -43,7 +46,7 @@ fn main() -> Result<()> {
 
     let expected_output = 42u32;
     let verifier = program.real_verifier(ProverLevel::RecursionUnified).build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/docs/src/01-installation-and-hello-world.md
+++ b/docs/src/01-installation-and-hello-world.md
@@ -130,6 +130,8 @@ cargo airbender generate-vk ./dist/app/app.bin --output ./vk.bin --level base
 cargo airbender verify-proof ./proof.bin --vk ./vk.bin
 ```
 
+Real proving defaults to 100-bit security. Add `--security 80` to both `prove` and `generate-vk` only when you need legacy 80-bit artifacts.
+
 For non-trivial inputs, use the host-side `Inputs::push(...)` API and `write_hex_file(...)` to generate input files. See [Host Program API](./02-host-program-api.md).
 
 ## Proving Hardware

--- a/docs/src/02-host-program-api.md
+++ b/docs/src/02-host-program-api.md
@@ -24,7 +24,7 @@ Load the program, push inputs, run it, then prove and verify. Runners and prover
 
 ```rust
 use airbender_host::{
-    Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier,
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
 };
 
 fn run() -> Result<()> {
@@ -41,12 +41,13 @@ fn run() -> Result<()> {
     println!("output x10={}", execution.receipt.output[0]);
 
     // Prove execution
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
 
     // Verify the proof
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,
@@ -87,36 +88,40 @@ Three prover backends are available:
 
 ```rust
 // Dev - no real cryptography, for local testing
-let prover = program.dev_prover().build()?;
+let prover = program.dev_prover()
+    .with_security(SecurityLevel::default())
+    .build()?;
 
 // GPU - full proving, requires NVIDIA GPU with 32GB+ VRAM
 let prover = program.gpu_prover()
     .with_level(ProverLevel::RecursionUnified)
     .build()?;
 
-// CPU - base layer only, mainly for debugging circuits
+// CPU - base layer only, mainly for debugging circuits.
+// Use 80-bit security only when producing legacy-compatible artifacts.
 let prover = program.cpu_prover()
+    .with_security(SecurityLevel::Bits80)
     .with_worker_threads(8)
     .build()?;
 ```
 
-All provers share the same interface: `prover.prove(inputs.words())`.
+Real CPU and GPU provers default to 100-bit security. Use `.with_security(SecurityLevel::Bits80)` only when you need legacy 80-bit artifacts. All provers share the same interface: `prover.prove(inputs.words())`.
 
 ## Verification
 
 ```rust
 // Dev verification
 let verifier = program.dev_verifier().build()?;
-let vk = verifier.generate_vk()?;
+let vk = verifier.generate_vk(SecurityLevel::default())?;
 verifier.verify(&proof, &vk, VerificationRequest::dev(inputs.words(), &expected))?;
 
 // Real verification (GPU-generated proofs)
 let verifier = program.real_verifier(ProverLevel::RecursionUnified).build()?;
-let vk = verifier.generate_vk()?;
+let vk = verifier.generate_vk(SecurityLevel::default())?;
 verifier.verify(&proof, &vk, VerificationRequest::real(&expected))?;
 ```
 
-Verification can optionally enforce expected public outputs (`x10..x17`) in addition to proof validity.
+Verification can optionally enforce expected public outputs (`x10..x17`) in addition to proof validity. Proofs and verification keys encode their security level, and verification rejects mismatched 80-bit/100-bit artifacts. Verification-key generation takes `SecurityLevel` explicitly so generic dev/real flows do not rely on hidden verifier-side defaults.
 
 ## Receipt Output
 

--- a/docs/src/05-cli-reference.md
+++ b/docs/src/05-cli-reference.md
@@ -162,6 +162,7 @@ cargo airbender prove ./dist/app/app.bin --input ./input.hex --output proof.bin
 |--------|-------------|
 | `--backend <dev\|cpu\|gpu>` | Prover backend (default: `dev`) |
 | `--level <base\|recursion-unrolled\|recursion-unified>` | Prover level (default: `recursion-unified`) |
+| `--security <80\|100>` | Security level recorded in proof artifacts (default: `100`) |
 | `--threads <n>` | Worker threads |
 | `--output <file>` | Output proof file (required) |
 | `--cycles <n>` | Cycle limit (dev and CPU backends) |
@@ -170,6 +171,13 @@ cargo airbender prove ./dist/app/app.bin --input ./input.hex --output proof.bin
 **Important:** `verify-proof` only accepts real proofs (CPU/GPU). Dev proofs are rejected with a clear error message.
 
 The `cpu` backend is for debugging circuits. It can only prove the base layer and is slow. Use `gpu` for real end-to-end proving.
+
+For legacy 80-bit real proofs, pass the same security level when proving and generating verification keys:
+
+```sh
+cargo airbender prove ./dist/app/app.bin --input ./input.hex --output proof.bin --backend gpu --security 80
+cargo airbender generate-vk ./dist/app/app.bin --output vk.bin --security 80
+```
 
 ---
 
@@ -185,6 +193,7 @@ cargo airbender generate-vk ./dist/app/app.bin --output vk.bin
 |--------|-------------|
 | `--output <file>` | Output path (default: `vk.bin`) |
 | `--level <base\|recursion-unrolled\|recursion-unified>` | VK level |
+| `--security <80\|100>` | Security level for verification keys (default: `100`) |
 
 ---
 
@@ -202,6 +211,7 @@ cargo airbender verify-proof ./proof.bin --vk ./vk.bin
 | `--expected-output <words>` | Expected public output (comma-separated, decimal or `0x` hex) |
 
 When `--expected-output` is omitted, only proof/VK validity is checked (with a warning). Fewer than 8 words are zero-padded.
+The proof and VK files carry their security level, so no `--security` flag is needed for verification.
 
 ```sh
 cargo airbender verify-proof ./proof.bin --vk ./vk.bin --expected-output 42

--- a/examples/cycle-markers/guest/Cargo.lock
+++ b/examples/cycle-markers/guest/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "unroll",
@@ -307,7 +307,10 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const-oid"
@@ -700,7 +703,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/cycle-markers/host/Cargo.lock
+++ b/examples/cycle-markers/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -94,10 +94,11 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -375,7 +376,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +435,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +447,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +457,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +589,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const_format"
@@ -640,15 +635,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -713,18 +699,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -783,18 +760,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -910,7 +877,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -923,7 +890,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -959,7 +926,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -972,7 +939,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1016,7 +983,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1086,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1140,15 +1107,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1205,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1217,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1266,7 +1224,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1278,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1291,23 +1249,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1319,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1362,7 +1310,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1374,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1384,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1396,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1446,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1458,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1470,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1480,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1490,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -1723,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1748,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1919,7 +1867,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1928,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1938,7 +1886,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2143,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2163,7 +2111,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2176,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2187,23 +2135,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2215,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2408,7 +2346,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2422,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -2462,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2545,7 +2483,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2557,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2595,7 +2533,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2610,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2822,7 +2760,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/fibonacci/guest/Cargo.lock
+++ b/examples/fibonacci/guest/Cargo.lock
@@ -78,7 +78,10 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "getrandom"
@@ -127,7 +130,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/fibonacci/host/Cargo.lock
+++ b/examples/fibonacci/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -94,10 +94,11 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -375,7 +376,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +435,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +447,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +457,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +589,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const_format"
@@ -640,15 +635,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -713,18 +699,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -783,18 +760,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -910,7 +877,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -923,7 +890,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -959,7 +926,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -972,7 +939,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1016,7 +983,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1086,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1140,15 +1107,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1205,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1217,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1266,7 +1224,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1278,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1291,23 +1249,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1319,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1362,7 +1310,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1374,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1384,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1396,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1446,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1458,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1470,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1480,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1490,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -1723,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1748,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1919,7 +1867,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1928,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1938,7 +1886,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2143,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2163,7 +2111,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2176,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2187,23 +2135,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2215,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2408,7 +2346,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2422,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -2462,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2545,7 +2483,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2557,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2595,7 +2533,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2610,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2822,7 +2760,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/fibonacci/host/src/main.rs
+++ b/examples/fibonacci/host/src/main.rs
@@ -1,4 +1,6 @@
-use airbender_host::{Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
@@ -27,7 +29,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     let proof_output = prove_result.receipt.output[0];
     println!(
@@ -40,7 +43,7 @@ fn main() -> Result<()> {
     );
 
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/examples/revm-basic/guest/Cargo.lock
+++ b/examples/revm-basic/guest/Cargo.lock
@@ -758,7 +758,10 @@ dependencies = [
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const-hex"
@@ -2185,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/revm-basic/host/Cargo.lock
+++ b/examples/revm-basic/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -86,10 +86,11 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -205,7 +206,7 @@ dependencies = [
  "ruint",
  "rustc-hash",
  "serde",
- "sha3 0.10.9",
+ "sha3",
 ]
 
 [[package]]
@@ -656,7 +657,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -668,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -746,7 +747,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -758,7 +759,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -768,7 +769,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "unroll",
 ]
@@ -780,15 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -970,15 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +970,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const-hex"
@@ -996,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "proptest",
  "serde_core",
 ]
@@ -1057,15 +1043,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1157,18 +1134,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -1315,20 +1283,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1461,26 +1419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "era_cudart"
-version = "0.156.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3f38cd4f1fa1c2535e30b1d1aa197b8f3c73d4368fbeb6524ac06fd7c23ef9"
-dependencies = [
- "bitflags",
- "era_cudart_sys",
- "paste",
-]
-
-[[package]]
-name = "era_cudart_sys"
-version = "0.156.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e6d410237bb86a4321999d771c0ea55c31a9073997c9657fe68ab6a255224a"
-dependencies = [
- "regex-lite",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,11 +1431,10 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
- "gpu_prover",
  "log",
  "prover_examples",
  "riscv_common",
@@ -1505,7 +1442,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -1557,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -1570,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1626,7 +1563,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1738,34 +1675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gpu_prover"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
-dependencies = [
- "blake2s_u32",
- "cmake",
- "crossbeam-channel",
- "crossbeam-utils",
- "cs",
- "era_cudart",
- "era_cudart_sys",
- "fft",
- "field",
- "itertools 0.14.0",
- "log",
- "nvtx",
- "prover",
- "rayon",
- "riscv_transpiler",
- "setups",
- "trace_and_split",
- "transpose",
- "type-map",
- "verifier_common",
- "worker",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,15 +1758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -1964,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1976,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2037,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2049,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2075,17 +1975,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2101,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2113,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2168,7 +2058,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2180,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2190,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2202,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2252,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2264,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2276,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2286,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2296,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -2427,15 +2317,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "nvtx"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2e855e8019f99e4b94ac33670eb4e4f570a2e044f3749a0b2c7f83b841e52c"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2696,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -2721,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -2904,12 +2785,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -3141,7 +3016,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -3150,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -3160,7 +3035,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -3480,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -3500,7 +3375,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -3513,7 +3388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -3524,17 +3399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -3550,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -3562,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -3639,12 +3504,6 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -3846,7 +3705,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -3860,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -3910,21 +3769,11 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
  "worker",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]
@@ -3999,7 +3848,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -4011,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -4049,7 +3898,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -4064,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -4514,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/revm-basic/host/src/main.rs
+++ b/examples/revm-basic/host/src/main.rs
@@ -1,4 +1,6 @@
-use airbender_host::{Inputs, Program, Prover, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use revm_basic_shared::RunInput;
 use std::path::PathBuf;
 
@@ -39,7 +41,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     assert_eq!(
         execution.receipt.output, prove_result.receipt.output,
@@ -47,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/examples/std-btreemap/guest/Cargo.lock
+++ b/examples/std-btreemap/guest/Cargo.lock
@@ -78,7 +78,10 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "getrandom"
@@ -127,7 +130,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/std-btreemap/host/Cargo.lock
+++ b/examples/std-btreemap/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -87,10 +87,11 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -375,7 +376,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -387,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -434,7 +435,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -446,7 +447,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -456,7 +457,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "unroll",
 ]
@@ -468,15 +469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -597,7 +589,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const_format"
@@ -640,15 +635,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -713,18 +699,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -783,18 +760,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -910,7 +877,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -923,7 +890,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -959,7 +926,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -972,7 +939,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1016,7 +983,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1086,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1140,15 +1107,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1205,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1217,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1266,7 +1224,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1278,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1291,23 +1249,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1319,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1362,7 +1310,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1374,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1384,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1396,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1446,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1458,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1470,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1480,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1490,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -1723,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1748,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1919,7 +1867,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1928,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1938,7 +1886,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2143,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2163,7 +2111,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2176,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2187,23 +2135,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2215,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2408,7 +2346,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2422,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -2462,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2545,7 +2483,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2557,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2595,7 +2533,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2610,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2822,7 +2760,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/std-btreemap/host/src/main.rs
+++ b/examples/std-btreemap/host/src/main.rs
@@ -1,4 +1,6 @@
-use airbender_host::{Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
@@ -28,7 +30,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     let proof_output = prove_result.receipt.output[0];
     println!(
@@ -37,7 +40,7 @@ fn main() -> Result<()> {
     );
 
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,

--- a/examples/u256-add/guest/Cargo.lock
+++ b/examples/u256-add/guest/Cargo.lock
@@ -91,7 +91,10 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "getrandom"
@@ -228,7 +231,7 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",

--- a/examples/u256-add/host/Cargo.lock
+++ b/examples/u256-add/host/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -87,10 +87,11 @@ dependencies = [
  "riscv_transpiler",
  "serde",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "sysinfo",
  "thiserror",
  "tracing",
+ "verifier_common",
 ]
 
 [[package]]
@@ -376,7 +377,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -388,7 +389,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -435,7 +436,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -447,7 +448,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -457,7 +458,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "unroll",
 ]
@@ -469,15 +470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -598,7 +590,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
+dependencies = [
+ "seq-macro",
+]
 
 [[package]]
 name = "const_format"
@@ -641,15 +636,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -714,18 +700,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -784,18 +761,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -911,7 +878,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -924,7 +891,7 @@ dependencies = [
  "serde",
  "serde_json",
  "setups",
- "sha3 0.11.0",
+ "sha3",
  "trace_and_split",
  "verifier_common",
 ]
@@ -960,7 +927,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "seq-macro",
@@ -973,7 +940,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1017,7 +984,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1087,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -1141,15 +1108,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "impl-codec"
@@ -1206,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1218,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1267,7 +1225,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1279,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1292,23 +1250,13 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1320,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1363,7 +1311,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1375,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1385,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1397,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1447,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1459,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -1471,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1481,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -1491,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 
 [[package]]
 name = "ntapi"
@@ -1724,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -1749,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -1920,7 +1868,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -1929,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "addr2line",
  "blake2s_u32",
@@ -1939,7 +1887,7 @@ dependencies = [
  "dynasmrt",
  "field",
  "inferno",
- "keccak 0.2.0",
+ "keccak",
  "object",
  "riscv-decode",
  "ruint",
@@ -2144,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -2164,7 +2112,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sha3 0.11.0",
+ "sha3",
  "shift_binary_csr",
  "syn 2.0.117",
  "unified_reduced_machine",
@@ -2177,7 +2125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -2188,23 +2136,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2216,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2409,7 +2347,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2423,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "worker",
@@ -2463,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -2546,7 +2484,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "common_constants",
  "prover",
@@ -2558,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "field",
  "unroll",
@@ -2596,7 +2534,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -2611,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "proc-macro2",
  "prover",
@@ -2823,7 +2761,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=73d69b5#73d69b5346b3c2350fa104a56ec4df78840cea99"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/examples/u256-add/host/src/main.rs
+++ b/examples/u256-add/host/src/main.rs
@@ -1,4 +1,6 @@
-use airbender_host::{Inputs, Program, Prover, Result, Runner, VerificationRequest, Verifier};
+use airbender_host::{
+    Inputs, Program, Prover, Result, Runner, SecurityLevel, VerificationRequest, Verifier,
+};
 use ruint::aliases::U256;
 use std::path::PathBuf;
 
@@ -32,7 +34,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let prover = program.dev_prover().build()?;
+    let security = SecurityLevel::default();
+    let prover = program.dev_prover().with_security(security).build()?;
     let prove_result = prover.prove(inputs.words())?;
     let proof_valid = prove_result.receipt.output[0] == 1;
     println!(
@@ -41,7 +44,7 @@ fn main() -> Result<()> {
     );
 
     let verifier = program.dev_verifier().build()?;
-    let vk = verifier.generate_vk()?;
+    let vk = verifier.generate_vk(security)?;
     verifier.verify(
         &prove_result.proof,
         &vk,


### PR DESCRIPTION
Updates the airbender dep to the latest dev, and makes use of non-mutually-exclusive security features.

Enables the runtime selection of chosen security level, with 100 bits being the default.

⚠️ This PR changes the stored vk/proof formats, heavily alters interfaces, and makes 100bit security the default instead of previous 80 bit. 

From now on, 80 bit will remain for compatibility in case some users cannot migrate for whatever reason.

Also, adds an e2e test on GPU.