### PR TITLE
feat: Support passing the machine configuration to the transpiler

### DIFF
--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -9,6 +9,7 @@
 mod cycle_marker;
 mod error;
 mod inputs;
+mod machine;
 mod program;
 mod proof;
 mod prover;
@@ -22,6 +23,7 @@ pub use airbender_core::guest::Commit;
 pub use cycle_marker::{CycleMarker, Mark};
 pub use error::{HostError, Result};
 pub use inputs::Inputs;
+pub use machine::MachineProfile;
 pub use program::Program;
 pub use proof::{DevProof, Proof, RealProof};
 pub use prover::{
@@ -52,4 +54,8 @@ pub use vk::{
 /// direct Airbender crates at the same time.
 pub mod raw {
     pub use execution_utils::unrolled::UnrolledProgramProof;
+    pub use riscv_transpiler::ir::{
+        DecodingOptions, FullMachineDecoderConfig, FullUnsignedMachineDecoderConfig,
+        ReducedMachineDecoderConfig,
+    };
 }

--- a/crates/airbender-host/src/machine.rs
+++ b/crates/airbender-host/src/machine.rs
@@ -1,0 +1,130 @@
+use riscv_transpiler::ir::{
+    preprocess_bytecode, DecodingOptions, FullUnsignedMachineDecoderConfig, Instruction,
+    ReducedMachineDecoderConfig,
+};
+
+/// Airbender Platform machine profiles with stable host-side semantics.
+///
+/// The upstream Airbender crates model machines as Rust types, which is useful
+/// internally but brittle as a public platform API. This enum is the small set
+/// of machine configurations that `airbender-host` is willing to name and keep
+/// stable for normal users.
+///
+/// Full-signed decoding is intentionally omitted from the stable profile set for
+/// now: upstream decoding can name signed multiplication/division instructions,
+/// but the host runner does not execute those instruction variants.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum MachineProfile {
+    /// Full machine without signed multiplication/division support.
+    #[default]
+    FullUnsigned,
+    /// Reduced machine used by recursive verifier workloads.
+    Reduced,
+}
+
+type PreprocessBytecodeFn = fn(&[u32]) -> Vec<Instruction>;
+
+#[derive(Clone, Copy)]
+pub(crate) struct TranspilerDecoderConfig {
+    name: &'static str,
+    preprocess_bytecode: PreprocessBytecodeFn,
+    pub(crate) stable_profile: Option<MachineProfile>,
+}
+
+impl TranspilerDecoderConfig {
+    pub(crate) fn from_profile(profile: MachineProfile) -> Self {
+        match profile {
+            MachineProfile::FullUnsigned => Self {
+                name: "full unsigned",
+                preprocess_bytecode: preprocess_bytecode::<FullUnsignedMachineDecoderConfig>,
+                stable_profile: Some(profile),
+            },
+            MachineProfile::Reduced => Self {
+                name: "reduced",
+                preprocess_bytecode: preprocess_bytecode::<ReducedMachineDecoderConfig>,
+                stable_profile: Some(profile),
+            },
+        }
+    }
+
+    pub(crate) fn unstable_raw<D>(name: &'static str) -> Self
+    where
+        D: DecodingOptions,
+    {
+        Self {
+            name,
+            preprocess_bytecode: preprocess_bytecode::<D>,
+            stable_profile: None,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub(crate) fn preprocess(&self, bytecode: &[u32]) -> Vec<Instruction> {
+        (self.preprocess_bytecode)(bytecode)
+    }
+}
+
+impl Default for TranspilerDecoderConfig {
+    fn default() -> Self {
+        Self::from_profile(MachineProfile::default())
+    }
+}
+
+impl std::fmt::Debug for TranspilerDecoderConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TranspilerDecoderConfig")
+            .field("name", &self.name)
+            .field("stable_profile", &self.stable_profile)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MachineProfile, TranspilerDecoderConfig};
+    use riscv_transpiler::ir::{
+        DebugReducedMachineDecoderConfig, FullMachineDecoderConfig, InstructionName,
+    };
+
+    const DIV_X3_X1_X2: u32 = 0x0220c1b3;
+    const LBU_X1_FROM_X0: u32 = 0x00004083;
+
+    #[test]
+    fn raw_decoder_can_opt_into_full_signed_decoding() {
+        let full_signed =
+            TranspilerDecoderConfig::unstable_raw::<FullMachineDecoderConfig>("test full signed")
+                .preprocess(&[DIV_X3_X1_X2]);
+        let full_unsigned = TranspilerDecoderConfig::from_profile(MachineProfile::FullUnsigned)
+            .preprocess(&[DIV_X3_X1_X2]);
+
+        assert_eq!(full_signed[0].name, InstructionName::Div);
+        assert_eq!(full_unsigned[0].name, InstructionName::Illegal);
+    }
+
+    #[test]
+    fn profile_controls_subword_memory_decoding() {
+        let full_unsigned = TranspilerDecoderConfig::from_profile(MachineProfile::FullUnsigned)
+            .preprocess(&[LBU_X1_FROM_X0]);
+        let reduced = TranspilerDecoderConfig::from_profile(MachineProfile::Reduced)
+            .preprocess(&[LBU_X1_FROM_X0]);
+
+        assert_eq!(full_unsigned[0].name, InstructionName::Lbu);
+        assert_eq!(reduced[0].name, InstructionName::Illegal);
+    }
+
+    #[test]
+    fn raw_decoder_accepts_upstream_decoder_configurations() {
+        let instructions =
+            TranspilerDecoderConfig::unstable_raw::<DebugReducedMachineDecoderConfig>(
+                "debug reduced",
+            )
+            .preprocess(&[LBU_X1_FROM_X0]);
+
+        assert_eq!(instructions[0].name, InstructionName::Lbu);
+    }
+}

--- a/crates/airbender-host/src/runner/transpiler_runner.rs
+++ b/crates/airbender-host/src/runner/transpiler_runner.rs
@@ -1,12 +1,13 @@
 use super::{resolve_cycles, ExecutionResult, FlamegraphConfig, Runner};
 use crate::error::{HostError, Result};
+use crate::machine::{MachineProfile, TranspilerDecoderConfig};
 use crate::receipt::Receipt;
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
 use riscv_transpiler::common_constants::{
     rom::ROM_SECOND_WORD_BITS, INITIAL_TIMESTAMP, TIMESTAMP_STEP,
 };
 use riscv_transpiler::cycle::CycleMarkerHooks;
-use riscv_transpiler::ir::{preprocess_bytecode, FullUnsignedMachineDecoderConfig};
+use riscv_transpiler::ir::DecodingOptions;
 #[cfg(target_arch = "x86_64")]
 use riscv_transpiler::jit::JittedCode;
 use riscv_transpiler::jit::RAM_SIZE;
@@ -23,6 +24,7 @@ pub struct TranspilerRunnerBuilder {
     cycles: Option<usize>,
     text_path: Option<PathBuf>,
     flamegraph: Option<FlamegraphConfig>,
+    decoder: TranspilerDecoderConfig,
     use_jit: bool,
 }
 
@@ -33,6 +35,7 @@ impl TranspilerRunnerBuilder {
             cycles: None,
             text_path: None,
             flamegraph: None,
+            decoder: TranspilerDecoderConfig::default(),
             use_jit: false,
         }
     }
@@ -66,12 +69,53 @@ impl TranspilerRunnerBuilder {
         self
     }
 
+    /// Selects one of the platform-supported machine profiles for bytecode preprocessing.
+    ///
+    /// The default is [`MachineProfile::FullUnsigned`], which preserves the historical
+    /// `airbender-host` transpiler behavior. Non-default profiles currently require
+    /// interpreter execution; combining them with [`Self::with_jit`] returns an error.
+    pub fn with_machine_profile(mut self, profile: MachineProfile) -> Self {
+        self.decoder = TranspilerDecoderConfig::from_profile(profile);
+        self
+    }
+
+    /// Selects a raw upstream decoder configuration.
+    ///
+    /// This method intentionally exposes `riscv_transpiler` internals and is not
+    /// covered by Airbender Platform's stability guarantees. It is intended for
+    /// advanced users who already accept that upstream Airbender APIs can change
+    /// without a platform-level compatibility layer. Raw decoders currently require
+    /// interpreter execution; combining them with [`Self::with_jit`] returns an error.
+    /// If the decoder emits instructions that the host runner does not implement,
+    /// execution may panic instead of returning a structured error.
+    ///
+    /// `name` is used only for diagnostics, so callers should pass a short domain
+    /// name that will make sense in error messages.
+    pub fn with_unstable_raw_decoder<D>(mut self, name: &'static str) -> Self
+    where
+        D: DecodingOptions,
+    {
+        self.decoder = TranspilerDecoderConfig::unstable_raw::<D>(name);
+        self
+    }
+
     pub fn with_jit(mut self) -> Self {
         self.use_jit = true;
         self
     }
 
     pub fn build(self) -> Result<TranspilerRunner> {
+        // Airbender's standalone JIT entry point accepts raw bytecode and is currently
+        // tailored for the full unsigned configuration. Enabling JIT for other profiles
+        // requires profile-aware support in Airbender itself so execution cannot bypass
+        // the decoder semantics that the interpreter path applies here.
+        if self.use_jit && self.decoder.stable_profile != Some(MachineProfile::FullUnsigned) {
+            return Err(HostError::Transpiler(format!(
+                "JIT execution is currently available only for the full unsigned machine profile; configured decoder is {}",
+                self.decoder.name()
+            )));
+        }
+
         if self.use_jit && cfg!(not(target_arch = "x86_64")) {
             return Err(HostError::Transpiler(
                 "JIT execution is only available on x86_64 targets".to_string(),
@@ -91,6 +135,7 @@ impl TranspilerRunnerBuilder {
             app_text_path,
             cycles,
             flamegraph: self.flamegraph,
+            decoder: self.decoder,
             use_jit: self.use_jit,
         })
     }
@@ -102,6 +147,7 @@ pub struct TranspilerRunner {
     app_text_path: PathBuf,
     cycles: usize,
     flamegraph: Option<FlamegraphConfig>,
+    decoder: TranspilerDecoderConfig,
     use_jit: bool,
 }
 
@@ -191,7 +237,7 @@ impl TranspilerRunner {
     ) -> Result<ExecutionResult> {
         let bin_words = read_u32_words(&self.app_bin_path)?;
         let text_words = read_u32_words(&self.app_text_path)?;
-        let instructions = preprocess_bytecode::<FullUnsignedMachineDecoderConfig>(&text_words);
+        let instructions = self.decoder.preprocess(&text_words);
         let instruction_tape = SimpleTape::new(&instructions);
         let mut ram =
             RamWithRomRegion::<{ ROM_SECOND_WORD_BITS }>::from_rom_content(&bin_words, RAM_SIZE);
@@ -313,6 +359,8 @@ fn read_u32_words(path: &Path) -> Result<Vec<u32>> {
 mod tests {
     use super::TranspilerRunnerBuilder;
     use crate::runner::Runner;
+    use crate::MachineProfile;
+    use riscv_transpiler::ir::DebugReducedMachineDecoderConfig;
     use std::path::Path;
 
     const MARKER_OPCODE: u32 = 0x7ff01073; // csrrw x0, 2047, x0
@@ -346,6 +394,27 @@ mod tests {
         assert!(diff.delegations.is_empty());
     }
 
+    #[test]
+    fn interpreter_runs_with_reduced_machine_profile() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let bin_path = dir.path().join("app.bin");
+        let text_path = dir.path().join("app.text");
+        let program = [ADDI_OPCODE, LOOP_OPCODE];
+        write_program(&bin_path, &program);
+        write_program(&text_path, &program);
+
+        let runner = TranspilerRunnerBuilder::new(&bin_path)
+            .with_text_path(&text_path)
+            .with_machine_profile(MachineProfile::Reduced)
+            .with_cycles(program.len())
+            .build()
+            .expect("build runner");
+        let execution = runner.run(&[]).expect("run program");
+
+        assert_eq!(execution.receipt.registers[1], 1);
+        assert!(execution.cycle_markers.is_some());
+    }
+
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn jit_runs_do_not_collect_cycle_markers() {
@@ -366,6 +435,42 @@ mod tests {
 
         assert_eq!(execution.receipt.registers[1], 1);
         assert!(execution.cycle_markers.is_none());
+    }
+
+    #[test]
+    fn jit_rejects_non_default_machine_profiles() {
+        let result = TranspilerRunnerBuilder::new("missing.bin")
+            .with_machine_profile(MachineProfile::Reduced)
+            .with_jit()
+            .build();
+        let err = match result {
+            Ok(_) => {
+                panic!("JIT should reject non-default machine profiles before path resolution")
+            }
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "transpiler error: JIT execution is currently available only for the full unsigned machine profile; configured decoder is reduced"
+        );
+    }
+
+    #[test]
+    fn jit_reports_raw_decoder_name() {
+        let result = TranspilerRunnerBuilder::new("missing.bin")
+            .with_unstable_raw_decoder::<DebugReducedMachineDecoderConfig>("debug reduced")
+            .with_jit()
+            .build();
+        let err = match result {
+            Ok(_) => panic!("JIT should reject raw decoders before path resolution"),
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "transpiler error: JIT execution is currently available only for the full unsigned machine profile; configured decoder is debug reduced"
+        );
     }
 
     fn write_program(path: &Path, program: &[u32]) {


### PR DESCRIPTION
Right now it's not possible to pass a custom machine configuration to the transpiler. This PR changes that by introducing two kinds of API:
- "stable", for curated machine configurations, that doesn't expose raw airbender APIs.
- "unstable", that lets you work with airbender types direcly for greater control.

Changes are currently only implemented for the transpiler, e.g. they are not propagated to other layers; this can be done on demand, shouldn't be hard.
