### PR TITLE
fix(ci): build release binaries without GPU prover

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -152,7 +152,7 @@ jobs:
           cache: false
 
       - name: Build debug binary
-        run: cargo build --bin cargo-airbender
+        run: cargo build --no-default-features --bin cargo-airbender
 
       - name: Build man page
         id: man
@@ -235,7 +235,7 @@ jobs:
         run: |
           target="${{ matrix.target }}"
 
-          cargo build --release --target "${target}" --bin cargo-airbender
+          cargo build --release --no-default-features --target "${target}" --bin cargo-airbender
 
           bin="./target/${target}/release/cargo-airbender"
           file "${bin}" || true


### PR DESCRIPTION
## Summary
- The `cargo-airbender` crate has `default = ["gpu-prover"]`, which pulls in `era_cudart_sys` and requires the CUDA Toolkit at build time.
- The release-binary matrix (linux x86_64/aarch64, macOS aarch64) and the man-page job run on CUDA-less runners, so the v0.2.0 release pipeline panicked at `build.rs:12` with `Failed to determine the CUDA Toolkit version` (run [26444831977](https://github.com/matter-labs/airbender-platform/actions/runs/26444831977)).
- Pass `--no-default-features` to both `cargo build` invocations in `ci-release.yaml`, matching what the non-CUDA Dockerfile already does. CUDA support continues to ship via the `cargo-airbender-cuda` Docker image.

## Test plan
- [ ] Re-run the release workflow for v0.2.0 (or dispatch manually) and confirm the three `Build <target>` jobs and the `Build man page` job succeed.
- [ ] Verify the resulting `cargo-airbender` binary still runs (`cargo-airbender --version`) on each platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)