### PR TITLE
fix(gpu-prover): unique batch_id_base per job

### DIFF
--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -255,6 +255,16 @@ fn gpu_worker_loop(
         return;
     }
 
+    // Distinct `batch_id_base` per job. `UnrolledProver::prove` derives its
+    // internal `batch_id` as `base * 10 + recursion_layer`, so a monotonic base
+    // keeps successive jobs from reusing the same `batch_id` sequence (0,1,2,…)
+    // — which was suspected of bleeding stale GPU state across back-to-back
+    // proofs and tripping `assert_caps_mach` around the third batch. The `*10`
+    // spacing assumes fewer than 10 recursion layers per job; jobs run
+    // sequentially here, so even an overflow only repeats an id the GPU manager
+    // has already flushed.
+    let mut next_batch_id_base: u64 = 0;
+
     while let Ok(command) = command_rx.recv() {
         match command {
             WorkerCommand::Prove {
@@ -262,8 +272,9 @@ fn gpu_worker_loop(
                 response_tx,
             } => {
                 let oracle = QuasiUARTSource::new_with_reads(input_words);
-                // TODO: we use `batch 0` for all the jobs, which can cause issues when generating multiple proofs in parallel.
-                let (inner_proof, cycles) = prover.prove(0, oracle);
+                let batch_id_base = next_batch_id_base;
+                next_batch_id_base += 1;
+                let (inner_proof, cycles) = prover.prove(batch_id_base, oracle);
                 let receipt = receipt_from_real_proof(&inner_proof);
                 let proof = Proof::Real(RealProof::new(security, level, inner_proof));
                 let result = Ok(ProveResult {


### PR DESCRIPTION
The GPU worker loop always proved with batch_id_base = 0, so every job reused the same internal batch_id sequence (0, 1, 2, …). This was the prime suspect for stale GPU state bleeding across back-to-back proofs in a long-lived ExecutionProver, tripping the assert_caps_mach soundness self-check around the third batch.

Hand each job a monotonically increasing batch_id_base so successive jobs no longer collide on batch_id. Replaces the upstream TODO at the call site.

# What

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and `cargo clippy`.
