### PR TITLE
chore(gpu-prover): unique batch_id_base per job (parallel-proof hygiene)

### DIFF
--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -255,6 +255,8 @@ fn gpu_worker_loop(
         return;
     }
 
+    let mut next_batch_id_base: u64 = 0;
+
     while let Ok(command) = command_rx.recv() {
         match command {
             WorkerCommand::Prove {
@@ -262,8 +264,9 @@ fn gpu_worker_loop(
                 response_tx,
             } => {
                 let oracle = QuasiUARTSource::new_with_reads(input_words);
-                // TODO: we use `batch 0` for all the jobs, which can cause issues when generating multiple proofs in parallel.
-                let (inner_proof, cycles) = prover.prove(0, oracle);
+                let batch_id_base = next_batch_id_base;
+                next_batch_id_base += 1;
+                let (inner_proof, cycles) = prover.prove(batch_id_base, oracle);
                 let receipt = receipt_from_real_proof(&inner_proof);
                 let proof = Proof::Real(RealProof::new(security, level, inner_proof));
                 let result = Ok(ProveResult {


### PR DESCRIPTION
## What

`GpuProver`'s worker loop always proved with `prover.prove(0, oracle)` — a hardcoded `batch_id_base = 0`. `UnrolledProver::prove` derives its internal `batch_id` as `base * 10 + recursion_layer`, so every job reused the identical `batch_id` sequence (0, 1, 2, …). This addresses the existing `// TODO: we use batch 0 for all the jobs, which can cause issues when generating multiple proofs in parallel` at the call site.

This change gives each job a distinct, monotonically increasing `batch_id_base`.

## Scope / honesty note

This is **hygiene only** — it makes `batch_id`s unique across jobs, which is correct for any parallel/reuse scenario. 

It was originally investigated as a fix for an `assert_caps_mach` soundness panic seen when reusing one long-lived GPU prover across multiple FRI batches. **That turned out to be wrong**: the panic reproduces on a *fresh* prover's *first* batch and is flaky (same input passes or fails nondeterministically). It is a `gpu_prover` bug specific to **Blackwell sm_120** (Ada sm_89 proves the same batches cleanly across repeated runs), unrelated to `batch_id`. That issue is being reported upstream to zksync-airbender separately.

So this PR does **not** fix that crash; it's just a small correctness/hygiene improvement that stands on its own. The `* 10` spacing assumes <10 recursion layers per job (observed peak: 7); jobs run sequentially so an overflow only repeats an id the GPU manager has already flushed.