### PR TITLE
feat(host): GpuProverConfig builder for the GPU prover

### DIFF
--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -30,7 +30,7 @@ pub use prover::{
     CpuProver, CpuProverBuilder, DevProver, DevProverBuilder, ProveResult, Prover, ProverLevel,
 };
 #[cfg(feature = "gpu-prover")]
-pub use prover::{ExecutionProverConfiguration, GpuProver, GpuProverBuilder, ProverContextConfig};
+pub use prover::{GpuProver, GpuProverBuilder, GpuProverConfig};
 pub use receipt::Receipt;
 pub use runner::{
     resolve_cycles, ExecutionResult, FlamegraphConfig, Runner, TranspilerRunner,

--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -30,7 +30,7 @@ pub use prover::{
     CpuProver, CpuProverBuilder, DevProver, DevProverBuilder, ProveResult, Prover, ProverLevel,
 };
 #[cfg(feature = "gpu-prover")]
-pub use prover::{GpuProver, GpuProverBuilder, HostBufferPoolConfig};
+pub use prover::{ExecutionProverConfiguration, GpuProver, GpuProverBuilder, ProverContextConfig};
 pub use receipt::Receipt;
 pub use runner::{
     resolve_cycles, ExecutionResult, FlamegraphConfig, Runner, TranspilerRunner,

--- a/crates/airbender-host/src/lib.rs
+++ b/crates/airbender-host/src/lib.rs
@@ -30,7 +30,7 @@ pub use prover::{
     CpuProver, CpuProverBuilder, DevProver, DevProverBuilder, ProveResult, Prover, ProverLevel,
 };
 #[cfg(feature = "gpu-prover")]
-pub use prover::{GpuProver, GpuProverBuilder};
+pub use prover::{GpuProver, GpuProverBuilder, HostBufferPoolConfig};
 pub use receipt::Receipt;
 pub use runner::{
     resolve_cycles, ExecutionResult, FlamegraphConfig, Runner, TranspilerRunner,

--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -5,28 +5,14 @@ use crate::error::{HostError, Result};
 use crate::proof::{Proof, RealProof};
 use crate::security::SecurityLevel;
 use execution_utils::unrolled_gpu::UnrolledProver;
-use gpu_prover::execution::prover::ExecutionProverConfiguration;
+pub use gpu_prover::execution::prover::ExecutionProverConfiguration;
+pub use gpu_prover::prover::context::ProverContextConfig;
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
 use std::any::Any;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Mutex};
 use std::thread::JoinHandle;
-
-/// Overrides for the GPU FRI prover's pinned host transfer-buffer pool.
-///
-/// The pool is allocated up front as `per_job × concurrent_jobs + per_device ×
-/// device_count` buffers, each a 64 MiB `cudaHostAlloc` (page-locked, committed
-/// RAM). Upstream defaults are 256/job + 128/device — 24 GiB on a single-GPU,
-/// single-job box. The pool is only ever trimmed back to a small free reserve
-/// (32 buffers), so most of it is prefetch/caching headroom; lowering these
-/// reclaims committed RAM at the cost of less pipelining. `None` leaves the
-/// upstream default for that axis untouched.
-#[derive(Clone, Copy, Default)]
-pub struct HostBufferPoolConfig {
-    pub allocators_per_job: Option<usize>,
-    pub allocators_per_device: Option<usize>,
-}
 
 /// Builder for creating a configured cached GPU prover.
 pub struct GpuProverBuilder {
@@ -35,7 +21,7 @@ pub struct GpuProverBuilder {
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
-    host_pool: HostBufferPoolConfig,
+    execution_config: Option<ExecutionProverConfiguration>,
 }
 
 impl GpuProverBuilder {
@@ -46,7 +32,7 @@ impl GpuProverBuilder {
             security: SecurityLevel::default(),
             level: ProverLevel::RecursionUnified,
             max_device_memory_bytes: None,
-            host_pool: HostBufferPoolConfig::default(),
+            execution_config: None,
         }
     }
 
@@ -81,11 +67,13 @@ impl GpuProverBuilder {
         self
     }
 
-    /// Overrides the pinned host transfer-buffer pool sizing. See
-    /// [`HostBufferPoolConfig`]; `None` on either axis keeps the upstream
-    /// default for that axis.
-    pub fn with_host_buffer_pool(mut self, host_pool: HostBufferPoolConfig) -> Self {
-        self.host_pool = host_pool;
+    /// Supplies the base [`ExecutionProverConfiguration`] for the underlying
+    /// prover (host buffer pool sizing, thread counts, concurrency, etc.).
+    /// When unset, the upstream `ExecutionProverConfiguration::default()` is
+    /// used. `with_worker_threads` and `with_max_device_memory_bytes` are
+    /// applied on top of this base, so they win if both are set.
+    pub fn with_execution_config(mut self, config: ExecutionProverConfiguration) -> Self {
+        self.execution_config = Some(config);
         self
     }
 
@@ -96,7 +84,7 @@ impl GpuProverBuilder {
             self.security,
             self.level,
             self.max_device_memory_bytes,
-            self.host_pool,
+            self.execution_config,
         )
     }
 }
@@ -133,7 +121,7 @@ impl GpuProver {
         security: SecurityLevel,
         level: ProverLevel,
         max_device_memory_bytes: Option<usize>,
-        host_pool: HostBufferPoolConfig,
+        execution_config: Option<ExecutionProverConfiguration>,
     ) -> Result<Self> {
         if matches!(worker_threads, Some(0)) {
             return Err(HostError::Prover(
@@ -148,7 +136,7 @@ impl GpuProver {
             security,
             level,
             max_device_memory_bytes,
-            host_pool,
+            execution_config,
         )?;
 
         Ok(Self {
@@ -236,7 +224,7 @@ fn spawn_worker(
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
-    host_pool: HostBufferPoolConfig,
+    execution_config: Option<ExecutionProverConfiguration>,
 ) -> Result<(mpsc::Sender<WorkerCommand>, JoinHandle<()>)> {
     let (command_tx, command_rx) = mpsc::channel();
     let (init_tx, init_rx) = mpsc::channel();
@@ -252,7 +240,7 @@ fn spawn_worker(
                 security,
                 level,
                 max_device_memory_bytes,
-                host_pool,
+                execution_config,
             )
         })
         .map_err(|err| {
@@ -286,7 +274,7 @@ fn gpu_worker_loop(
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
-    host_pool: HostBufferPoolConfig,
+    execution_config: Option<ExecutionProverConfiguration>,
 ) {
     // Keep all prover state inside this dedicated thread so a panic does not unwind
     // through host-call boundaries or require `AssertUnwindSafe`.
@@ -296,7 +284,7 @@ fn gpu_worker_loop(
         security,
         level.as_unrolled_level(),
         max_device_memory_bytes,
-        host_pool,
+        execution_config,
     ) {
         Ok(prover) => prover,
         Err(err) => {
@@ -352,22 +340,14 @@ fn create_unrolled_prover(
     security: SecurityLevel,
     level: execution_utils::unrolled_gpu::UnrolledProverLevel,
     max_device_memory_bytes: Option<usize>,
-    host_pool: HostBufferPoolConfig,
+    execution_config: Option<ExecutionProverConfiguration>,
 ) -> Result<UnrolledProver> {
     let base_path = base_path(app_bin_path)?;
-    let mut configuration = ExecutionProverConfiguration::default();
-    // Optionally trim the pinned host transfer-buffer pool below the upstream
-    // defaults (256/job + 128/device, each a 64 MiB cudaHostAlloc = 24 GiB on a
-    // single-GPU/single-job box). The pool is only ever trimmed back to a small
-    // free reserve, so most of it is prefetch/caching headroom; lowering these
-    // reclaims committed RAM at the cost of less pipelining. Left at the upstream
-    // default unless the caller overrides an axis. See `HostBufferPoolConfig`.
-    if let Some(per_job) = host_pool.allocators_per_job {
-        configuration.host_allocators_per_job_count = per_job;
-    }
-    if let Some(per_device) = host_pool.allocators_per_device {
-        configuration.host_allocators_per_device_count = per_device;
-    }
+    // Start from the caller-supplied prover configuration (host buffer pool
+    // sizing, thread counts, concurrency, ...) or the upstream default when
+    // none was provided. The dedicated `worker_threads` and
+    // `max_device_memory_bytes` overrides below are applied on top of this base.
+    let mut configuration = execution_config.unwrap_or_default();
     if let Some(threads) = worker_threads {
         configuration.max_thread_pool_threads = Some(threads);
         configuration.replay_worker_threads_count = threads;

--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -5,8 +5,7 @@ use crate::error::{HostError, Result};
 use crate::proof::{Proof, RealProof};
 use crate::security::SecurityLevel;
 use execution_utils::unrolled_gpu::UnrolledProver;
-pub use gpu_prover::execution::prover::ExecutionProverConfiguration;
-pub use gpu_prover::prover::context::ProverContextConfig;
+use gpu_prover::execution::prover::ExecutionProverConfiguration;
 use riscv_transpiler::abstractions::non_determinism::QuasiUARTSource;
 use std::any::Any;
 use std::path::{Path, PathBuf};
@@ -14,38 +13,33 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Mutex};
 use std::thread::JoinHandle;
 
-/// Builder for creating a configured cached GPU prover.
-pub struct GpuProverBuilder {
-    app_bin_path: PathBuf,
+/// Low-level configuration for the GPU prover.
+///
+/// The default configuration is meant to be optimal in the vast majority of
+/// cases, so overriding it is only recommended if you either have specific
+/// constraints or you need to fine-tune the configuration for a specific and
+/// unusual workload. Each field left unset keeps the prover's own default.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GpuProverConfig {
     worker_threads: Option<usize>,
-    security: SecurityLevel,
-    level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
-    execution_config: Option<ExecutionProverConfiguration>,
+    host_allocators_per_job: Option<usize>,
+    host_allocators_per_device: Option<usize>,
 }
 
-impl GpuProverBuilder {
-    pub fn new(app_bin_path: impl AsRef<Path>) -> Self {
-        Self {
-            app_bin_path: app_bin_path.as_ref().to_path_buf(),
-            worker_threads: None,
-            security: SecurityLevel::default(),
-            level: ProverLevel::RecursionUnified,
-            max_device_memory_bytes: None,
-            execution_config: None,
-        }
-    }
-
+impl GpuProverConfig {
+    /// Number of worker threads for the prover's thread pool and replay workers.
     pub fn with_worker_threads(mut self, worker_threads: usize) -> Self {
         self.worker_threads = Some(worker_threads);
         self
     }
 
-    pub fn maybe_worker_threads(self, worker_threads: Option<usize>) -> Self {
-        match worker_threads {
-            Some(v) => self.with_worker_threads(v),
-            None => self,
+    /// Like [`Self::with_worker_threads`] but a no-op when `None`.
+    pub fn maybe_worker_threads(mut self, worker_threads: Option<usize>) -> Self {
+        if let Some(worker_threads) = worker_threads {
+            self.worker_threads = Some(worker_threads);
         }
+        self
     }
 
     /// Caps the GPU device allocator at `bytes`. By default the allocator grabs
@@ -55,6 +49,40 @@ impl GpuProverBuilder {
     pub fn with_max_device_memory_bytes(mut self, bytes: usize) -> Self {
         self.max_device_memory_bytes = Some(bytes);
         self
+    }
+
+    /// Pinned host transfer buffers pre-allocated per concurrent job (64 MiB
+    /// each). Lowering this below the prover default reclaims committed RAM at
+    /// the cost of less host<->device pipelining.
+    pub fn with_host_allocators_per_job(mut self, count: usize) -> Self {
+        self.host_allocators_per_job = Some(count);
+        self
+    }
+
+    /// Pinned host transfer buffers pre-allocated per GPU device (64 MiB each).
+    /// See [`Self::with_host_allocators_per_job`].
+    pub fn with_host_allocators_per_device(mut self, count: usize) -> Self {
+        self.host_allocators_per_device = Some(count);
+        self
+    }
+}
+
+/// Builder for creating a configured cached GPU prover.
+pub struct GpuProverBuilder {
+    app_bin_path: PathBuf,
+    security: SecurityLevel,
+    level: ProverLevel,
+    config: GpuProverConfig,
+}
+
+impl GpuProverBuilder {
+    pub fn new(app_bin_path: impl AsRef<Path>) -> Self {
+        Self {
+            app_bin_path: app_bin_path.as_ref().to_path_buf(),
+            security: SecurityLevel::default(),
+            level: ProverLevel::RecursionUnified,
+            config: GpuProverConfig::default(),
+        }
     }
 
     pub fn with_level(mut self, level: ProverLevel) -> Self {
@@ -67,25 +95,17 @@ impl GpuProverBuilder {
         self
     }
 
-    /// Supplies the base [`ExecutionProverConfiguration`] for the underlying
-    /// prover (host buffer pool sizing, thread counts, concurrency, etc.).
-    /// When unset, the upstream `ExecutionProverConfiguration::default()` is
-    /// used. `with_worker_threads` and `with_max_device_memory_bytes` are
-    /// applied on top of this base, so they win if both are set.
-    pub fn with_execution_config(mut self, config: ExecutionProverConfiguration) -> Self {
-        self.execution_config = Some(config);
+    /// Applies low-level configuration for the GPU prover. See
+    /// [`GpuProverConfig`]; the default is optimal for the vast majority of
+    /// workloads, so this is only needed for specific constraints or unusual
+    /// workloads.
+    pub fn with_config(mut self, config: GpuProverConfig) -> Self {
+        self.config = config;
         self
     }
 
     pub fn build(self) -> Result<GpuProver> {
-        GpuProver::new(
-            &self.app_bin_path,
-            self.worker_threads,
-            self.security,
-            self.level,
-            self.max_device_memory_bytes,
-            self.execution_config,
-        )
+        GpuProver::new(&self.app_bin_path, self.security, self.level, self.config)
     }
 }
 
@@ -117,27 +137,18 @@ enum WorkerCommand {
 impl GpuProver {
     fn new(
         app_bin_path: &Path,
-        worker_threads: Option<usize>,
         security: SecurityLevel,
         level: ProverLevel,
-        max_device_memory_bytes: Option<usize>,
-        execution_config: Option<ExecutionProverConfiguration>,
+        config: GpuProverConfig,
     ) -> Result<Self> {
-        if matches!(worker_threads, Some(0)) {
+        if matches!(config.worker_threads, Some(0)) {
             return Err(HostError::Prover(
                 "worker thread count must be greater than zero".to_string(),
             ));
         }
 
         let app_bin_path = resolve_app_bin_path(app_bin_path)?;
-        let (command_tx, worker_handle) = spawn_worker(
-            app_bin_path,
-            worker_threads,
-            security,
-            level,
-            max_device_memory_bytes,
-            execution_config,
-        )?;
+        let (command_tx, worker_handle) = spawn_worker(app_bin_path, security, level, config)?;
 
         Ok(Self {
             command_tx,
@@ -220,29 +231,16 @@ impl Drop for GpuProver {
 
 fn spawn_worker(
     app_bin_path: PathBuf,
-    worker_threads: Option<usize>,
     security: SecurityLevel,
     level: ProverLevel,
-    max_device_memory_bytes: Option<usize>,
-    execution_config: Option<ExecutionProverConfiguration>,
+    config: GpuProverConfig,
 ) -> Result<(mpsc::Sender<WorkerCommand>, JoinHandle<()>)> {
     let (command_tx, command_rx) = mpsc::channel();
     let (init_tx, init_rx) = mpsc::channel();
 
     let worker_handle = std::thread::Builder::new()
         .name("airbender-gpu-prover".to_string())
-        .spawn(move || {
-            gpu_worker_loop(
-                command_rx,
-                init_tx,
-                app_bin_path,
-                worker_threads,
-                security,
-                level,
-                max_device_memory_bytes,
-                execution_config,
-            )
-        })
+        .spawn(move || gpu_worker_loop(command_rx, init_tx, app_bin_path, security, level, config))
         .map_err(|err| {
             HostError::Prover(format!("failed to spawn GPU prover worker thread: {err}"))
         })?;
@@ -270,28 +268,20 @@ fn gpu_worker_loop(
     command_rx: mpsc::Receiver<WorkerCommand>,
     init_tx: mpsc::Sender<Result<()>>,
     app_bin_path: PathBuf,
-    worker_threads: Option<usize>,
     security: SecurityLevel,
     level: ProverLevel,
-    max_device_memory_bytes: Option<usize>,
-    execution_config: Option<ExecutionProverConfiguration>,
+    config: GpuProverConfig,
 ) {
     // Keep all prover state inside this dedicated thread so a panic does not unwind
     // through host-call boundaries or require `AssertUnwindSafe`.
-    let prover = match create_unrolled_prover(
-        &app_bin_path,
-        worker_threads,
-        security,
-        level.as_unrolled_level(),
-        max_device_memory_bytes,
-        execution_config,
-    ) {
-        Ok(prover) => prover,
-        Err(err) => {
-            let _ = init_tx.send(Err(err));
-            return;
-        }
-    };
+    let prover =
+        match create_unrolled_prover(&app_bin_path, security, level.as_unrolled_level(), config) {
+            Ok(prover) => prover,
+            Err(err) => {
+                let _ = init_tx.send(Err(err));
+                return;
+            }
+        };
 
     if init_tx.send(Ok(())).is_err() {
         return;
@@ -336,23 +326,25 @@ fn panic_payload_to_string(payload: Box<dyn Any + Send + 'static>) -> String {
 
 fn create_unrolled_prover(
     app_bin_path: &Path,
-    worker_threads: Option<usize>,
     security: SecurityLevel,
     level: execution_utils::unrolled_gpu::UnrolledProverLevel,
-    max_device_memory_bytes: Option<usize>,
-    execution_config: Option<ExecutionProverConfiguration>,
+    config: GpuProverConfig,
 ) -> Result<UnrolledProver> {
     let base_path = base_path(app_bin_path)?;
-    // Start from the caller-supplied prover configuration (host buffer pool
-    // sizing, thread counts, concurrency, ...) or the upstream default when
-    // none was provided. The dedicated `worker_threads` and
-    // `max_device_memory_bytes` overrides below are applied on top of this base.
-    let mut configuration = execution_config.unwrap_or_default();
-    if let Some(threads) = worker_threads {
+    // Map the host-level GpuProverConfig onto the prover's own configuration,
+    // leaving any field the caller did not set at the prover default.
+    let mut configuration = ExecutionProverConfiguration::default();
+    if let Some(threads) = config.worker_threads {
         configuration.max_thread_pool_threads = Some(threads);
         configuration.replay_worker_threads_count = threads;
     }
-    if let Some(bytes) = max_device_memory_bytes {
+    if let Some(count) = config.host_allocators_per_job {
+        configuration.host_allocators_per_job_count = count;
+    }
+    if let Some(count) = config.host_allocators_per_device {
+        configuration.host_allocators_per_device_count = count;
+    }
+    if let Some(bytes) = config.max_device_memory_bytes {
         // The device allocator works in fixed-size blocks; translate the byte cap
         // into a block count. A cap below one block is rejected rather than
         // silently rounded to zero (which would mean "use all free memory").

--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -323,6 +323,18 @@ fn create_unrolled_prover(
 ) -> Result<UnrolledProver> {
     let base_path = base_path(app_bin_path)?;
     let mut configuration = ExecutionProverConfiguration::default();
+    // Trim the pinned host transfer-buffer pool below the upstream defaults
+    // (256/job + 128/device, each backed by a 64 MiB cudaHostAlloc = 24 GiB on a
+    // single-GPU/single-job box). The pool feeds one `free_allocators` channel and
+    // is only trimmed back to `min_free_host_allocators_per_job` (32) buffers, so
+    // the bulk of it is prefetch/caching headroom rather than live working set.
+    // We cut the pure device-headroom term hardest (128 -> 64) and the per-job
+    // working term lightly (256 -> 224), leaving 288 buffers (= 18 GiB, still 9x
+    // the 32-buffer trim floor). Net: -6 GiB committed pinned RAM at startup.
+    // This is a memory/perf trade-off only (smaller cache => less pipelining), not
+    // a correctness change; revisit if proving time regresses or buffers starve.
+    configuration.host_allocators_per_job_count = 224;
+    configuration.host_allocators_per_device_count = 64;
     if let Some(threads) = worker_threads {
         configuration.max_thread_pool_threads = Some(threads);
         configuration.replay_worker_threads_count = threads;

--- a/crates/airbender-host/src/prover/gpu_prover.rs
+++ b/crates/airbender-host/src/prover/gpu_prover.rs
@@ -13,6 +13,21 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Mutex};
 use std::thread::JoinHandle;
 
+/// Overrides for the GPU FRI prover's pinned host transfer-buffer pool.
+///
+/// The pool is allocated up front as `per_job × concurrent_jobs + per_device ×
+/// device_count` buffers, each a 64 MiB `cudaHostAlloc` (page-locked, committed
+/// RAM). Upstream defaults are 256/job + 128/device — 24 GiB on a single-GPU,
+/// single-job box. The pool is only ever trimmed back to a small free reserve
+/// (32 buffers), so most of it is prefetch/caching headroom; lowering these
+/// reclaims committed RAM at the cost of less pipelining. `None` leaves the
+/// upstream default for that axis untouched.
+#[derive(Clone, Copy, Default)]
+pub struct HostBufferPoolConfig {
+    pub allocators_per_job: Option<usize>,
+    pub allocators_per_device: Option<usize>,
+}
+
 /// Builder for creating a configured cached GPU prover.
 pub struct GpuProverBuilder {
     app_bin_path: PathBuf,
@@ -20,6 +35,7 @@ pub struct GpuProverBuilder {
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
+    host_pool: HostBufferPoolConfig,
 }
 
 impl GpuProverBuilder {
@@ -30,6 +46,7 @@ impl GpuProverBuilder {
             security: SecurityLevel::default(),
             level: ProverLevel::RecursionUnified,
             max_device_memory_bytes: None,
+            host_pool: HostBufferPoolConfig::default(),
         }
     }
 
@@ -64,6 +81,14 @@ impl GpuProverBuilder {
         self
     }
 
+    /// Overrides the pinned host transfer-buffer pool sizing. See
+    /// [`HostBufferPoolConfig`]; `None` on either axis keeps the upstream
+    /// default for that axis.
+    pub fn with_host_buffer_pool(mut self, host_pool: HostBufferPoolConfig) -> Self {
+        self.host_pool = host_pool;
+        self
+    }
+
     pub fn build(self) -> Result<GpuProver> {
         GpuProver::new(
             &self.app_bin_path,
@@ -71,6 +96,7 @@ impl GpuProverBuilder {
             self.security,
             self.level,
             self.max_device_memory_bytes,
+            self.host_pool,
         )
     }
 }
@@ -107,6 +133,7 @@ impl GpuProver {
         security: SecurityLevel,
         level: ProverLevel,
         max_device_memory_bytes: Option<usize>,
+        host_pool: HostBufferPoolConfig,
     ) -> Result<Self> {
         if matches!(worker_threads, Some(0)) {
             return Err(HostError::Prover(
@@ -121,6 +148,7 @@ impl GpuProver {
             security,
             level,
             max_device_memory_bytes,
+            host_pool,
         )?;
 
         Ok(Self {
@@ -208,6 +236,7 @@ fn spawn_worker(
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
+    host_pool: HostBufferPoolConfig,
 ) -> Result<(mpsc::Sender<WorkerCommand>, JoinHandle<()>)> {
     let (command_tx, command_rx) = mpsc::channel();
     let (init_tx, init_rx) = mpsc::channel();
@@ -223,6 +252,7 @@ fn spawn_worker(
                 security,
                 level,
                 max_device_memory_bytes,
+                host_pool,
             )
         })
         .map_err(|err| {
@@ -256,6 +286,7 @@ fn gpu_worker_loop(
     security: SecurityLevel,
     level: ProverLevel,
     max_device_memory_bytes: Option<usize>,
+    host_pool: HostBufferPoolConfig,
 ) {
     // Keep all prover state inside this dedicated thread so a panic does not unwind
     // through host-call boundaries or require `AssertUnwindSafe`.
@@ -265,6 +296,7 @@ fn gpu_worker_loop(
         security,
         level.as_unrolled_level(),
         max_device_memory_bytes,
+        host_pool,
     ) {
         Ok(prover) => prover,
         Err(err) => {
@@ -320,21 +352,22 @@ fn create_unrolled_prover(
     security: SecurityLevel,
     level: execution_utils::unrolled_gpu::UnrolledProverLevel,
     max_device_memory_bytes: Option<usize>,
+    host_pool: HostBufferPoolConfig,
 ) -> Result<UnrolledProver> {
     let base_path = base_path(app_bin_path)?;
     let mut configuration = ExecutionProverConfiguration::default();
-    // Trim the pinned host transfer-buffer pool below the upstream defaults
-    // (256/job + 128/device, each backed by a 64 MiB cudaHostAlloc = 24 GiB on a
-    // single-GPU/single-job box). The pool feeds one `free_allocators` channel and
-    // is only trimmed back to `min_free_host_allocators_per_job` (32) buffers, so
-    // the bulk of it is prefetch/caching headroom rather than live working set.
-    // We cut the pure device-headroom term hardest (128 -> 64) and the per-job
-    // working term lightly (256 -> 224), leaving 288 buffers (= 18 GiB, still 9x
-    // the 32-buffer trim floor). Net: -6 GiB committed pinned RAM at startup.
-    // This is a memory/perf trade-off only (smaller cache => less pipelining), not
-    // a correctness change; revisit if proving time regresses or buffers starve.
-    configuration.host_allocators_per_job_count = 224;
-    configuration.host_allocators_per_device_count = 64;
+    // Optionally trim the pinned host transfer-buffer pool below the upstream
+    // defaults (256/job + 128/device, each a 64 MiB cudaHostAlloc = 24 GiB on a
+    // single-GPU/single-job box). The pool is only ever trimmed back to a small
+    // free reserve, so most of it is prefetch/caching headroom; lowering these
+    // reclaims committed RAM at the cost of less pipelining. Left at the upstream
+    // default unless the caller overrides an axis. See `HostBufferPoolConfig`.
+    if let Some(per_job) = host_pool.allocators_per_job {
+        configuration.host_allocators_per_job_count = per_job;
+    }
+    if let Some(per_device) = host_pool.allocators_per_device {
+        configuration.host_allocators_per_device_count = per_device;
+    }
     if let Some(threads) = worker_threads {
         configuration.max_thread_pool_threads = Some(threads);
         configuration.replay_worker_threads_count = threads;

--- a/crates/airbender-host/src/prover/mod.rs
+++ b/crates/airbender-host/src/prover/mod.rs
@@ -12,7 +12,7 @@ mod gpu_prover;
 pub use self::cpu_prover::{CpuProver, CpuProverBuilder};
 pub use self::dev_prover::{DevProver, DevProverBuilder};
 #[cfg(feature = "gpu-prover")]
-pub use self::gpu_prover::{GpuProver, GpuProverBuilder};
+pub use self::gpu_prover::{GpuProver, GpuProverBuilder, HostBufferPoolConfig};
 
 pub(super) const DEFAULT_RAM_BOUND_BYTES: usize = 1 << 30;
 pub(super) const DEFAULT_CPU_CYCLE_BOUND: usize = u32::MAX as usize;

--- a/crates/airbender-host/src/prover/mod.rs
+++ b/crates/airbender-host/src/prover/mod.rs
@@ -12,9 +12,7 @@ mod gpu_prover;
 pub use self::cpu_prover::{CpuProver, CpuProverBuilder};
 pub use self::dev_prover::{DevProver, DevProverBuilder};
 #[cfg(feature = "gpu-prover")]
-pub use self::gpu_prover::{
-    ExecutionProverConfiguration, GpuProver, GpuProverBuilder, ProverContextConfig,
-};
+pub use self::gpu_prover::{GpuProver, GpuProverBuilder, GpuProverConfig};
 
 pub(super) const DEFAULT_RAM_BOUND_BYTES: usize = 1 << 30;
 pub(super) const DEFAULT_CPU_CYCLE_BOUND: usize = u32::MAX as usize;

--- a/crates/airbender-host/src/prover/mod.rs
+++ b/crates/airbender-host/src/prover/mod.rs
@@ -12,7 +12,9 @@ mod gpu_prover;
 pub use self::cpu_prover::{CpuProver, CpuProverBuilder};
 pub use self::dev_prover::{DevProver, DevProverBuilder};
 #[cfg(feature = "gpu-prover")]
-pub use self::gpu_prover::{GpuProver, GpuProverBuilder, HostBufferPoolConfig};
+pub use self::gpu_prover::{
+    ExecutionProverConfiguration, GpuProver, GpuProverBuilder, ProverContextConfig,
+};
 
 pub(super) const DEFAULT_RAM_BOUND_BYTES: usize = 1 << 30;
 pub(super) const DEFAULT_CPU_CYCLE_BOUND: usize = u32::MAX as usize;

--- a/crates/cargo-airbender/src/commands/prove.rs
+++ b/crates/cargo-airbender/src/commands/prove.rs
@@ -52,7 +52,10 @@ pub fn run(args: ProveArgs) -> Result<()> {
                 let prover = airbender_host::GpuProverBuilder::new(&args.app_bin)
                     .with_level(level)
                     .with_security(security)
-                    .maybe_worker_threads(args.threads)
+                    .with_config(
+                        airbender_host::GpuProverConfig::default()
+                            .maybe_worker_threads(args.threads),
+                    )
                     .build()
                     .map_err(|err| {
                     CliError::with_source(


### PR DESCRIPTION
## Summary

Adds a small **`GpuProverConfig`** that airbender-host owns, letting callers tune the GPU prover through one coherent builder — without exposing `gpu_prover`'s internal `ExecutionProverConfiguration` as public library API.

## API

```rust
GpuProverBuilder::new(app_bin)
    .with_level(level)
    .with_security(security)
    .with_config(
        GpuProverConfig::default()
            .maybe_worker_threads(threads)
            .with_host_allocators_per_job(224)     // default 256
            .with_host_allocators_per_device(64),  // default 128
    )
    .build()?;
```

`GpuProverConfig` covers worker threads, the device-memory cap (keeps byte→block validation), and the pinned host transfer-buffer pool. Each unset field keeps the prover's own (optimal) default; `create_unrolled_prover` just maps it onto `ExecutionProverConfiguration`.

## Motivation

The main consumer trims the host transfer-buffer pool (256/job + 128/device → 224/64, each 64 MiB) to reclaim ~6 GiB of committed pinned RAM at startup — now a normal config override.

## Notes

- Replaces the earlier per-knob setters / raw-config approach; `cargo-airbender` updated to `with_config`.
- Config/perf only, **not** a correctness change — defaults are unchanged unless a caller opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)