### PR TITLE
feat(crypto): add Affine::to_xy_bytes() for secp256k1

### DIFF
--- a/crates/airbender-crypto/src/secp256k1/points/affine.rs
+++ b/crates/airbender-crypto/src/secp256k1/points/affine.rs
@@ -269,8 +269,15 @@ impl Affine {
     /// Returns raw x||y coordinate bytes (64 bytes) without the 0x04 prefix byte
     /// and without the constant-time infinity check of `to_encoded_point`.
     ///
-    /// The caller must ensure the point is not at infinity before calling this.
+    /// The caller must ensure the point is not at infinity before calling this;
+    /// on an infinity point the raw coordinates would be all-zero, which is a
+    /// silent and easy-to-misread result. Guard with an assert instead (a plain
+    /// branch, far cheaper than the constant-time check this helper avoids).
     pub fn to_xy_bytes(self) -> [u8; 64] {
+        assert!(
+            !self.is_infinity(),
+            "to_xy_bytes called on the point at infinity"
+        );
         let x_bytes = self.x.to_bytes();
         let y_bytes = self.y.to_bytes();
         let mut result = [0u8; 64];

--- a/crates/airbender-crypto/src/secp256k1/points/affine.rs
+++ b/crates/airbender-crypto/src/secp256k1/points/affine.rs
@@ -265,6 +265,19 @@ impl Affine {
         result[..encoded.len()].copy_from_slice(encoded.as_bytes());
         result
     }
+
+    /// Returns raw x||y coordinate bytes (64 bytes) without the 0x04 prefix byte
+    /// and without the constant-time infinity check of `to_encoded_point`.
+    ///
+    /// The caller must ensure the point is not at infinity before calling this.
+    pub fn to_xy_bytes(self) -> [u8; 64] {
+        let x_bytes = self.x.to_bytes();
+        let y_bytes = self.y.to_bytes();
+        let mut result = [0u8; 64];
+        result[..32].copy_from_slice(&x_bytes);
+        result[32..].copy_from_slice(&y_bytes);
+        result
+    }
 }
 
 #[cfg(test)]
@@ -296,7 +309,7 @@ impl proptest::arbitrary::Arbitrary for Affine {
 mod tests {
     use super::Affine;
 
-    use proptest::{prop_assert_eq, proptest};
+    use proptest::{prop_assert_eq, prop_assume, proptest};
 
     #[test]
     fn test_set_xo() {
@@ -312,6 +325,18 @@ mod tests {
     fn jacobian_round_trip() {
         proptest!(|(x: Affine)| {
             prop_assert_eq!(x.to_jacobian().to_affine(), x);
+        });
+    }
+
+    #[test]
+    fn to_xy_bytes_matches_encoded_point() {
+        // For any non-infinity point, the raw x||y bytes must equal the body of
+        // the uncompressed encoded point (which is `0x04 || x || y`).
+        proptest!(|(p: Affine)| {
+            prop_assume!(!p.is_infinity());
+            let encoded = p.to_encoded_point(false);
+            let xy = p.to_xy_bytes();
+            prop_assert_eq!(&xy[..], &encoded.as_bytes()[1..]);
         });
     }
 }


### PR DESCRIPTION
# What

Adds `Affine::to_xy_bytes()` to the secp256k1 implementation: it returns the raw `x || y` coordinate bytes (64 bytes) of an affine point directly, bypassing the 65-byte `EncodedPoint` construction, its `ConditionallySelectable` infinity check, and the `0x04` prefix byte. The caller must ensure the point is not at infinity before calling it.

## Why

This is the `airbender-crypto`-side change required by the ZKsync OS ecrecover optimization ([matter-labs/zksync-os#584](https://github.com/matter-labs/zksync-os/pull/584)). In the ecrecover address-derivation path, point-at-infinity is already checked by `recover_with_context`, and the caller immediately discards the `0x04` prefix — so the `EncodedPoint` round-trip and its constant-time infinity check are pure overhead on one of the largest non-interpreter proving hotspots.

The consumer change (using `to_xy_bytes()` in `ecrecover_inner`) stays in ZKsync OS and will be re-applied there once this lands and the `airbender-crypto` rev is bumped.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)